### PR TITLE
feat: Rewrite and improve overlay alignment modifiers

### DIFF
--- a/demo-android/src/main/kotlin/com/svenjacobs/reveal/demo/ui/MainScreen.kt
+++ b/demo-android/src/main/kotlin/com/svenjacobs/reveal/demo/ui/MainScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.svenjacobs.reveal.Key
 import com.svenjacobs.reveal.Reveal
-import com.svenjacobs.reveal.RevealOverlayAlignment
+import com.svenjacobs.reveal.RevealOverlayArrangement
 import com.svenjacobs.reveal.RevealOverlayScope
 import com.svenjacobs.reveal.RevealShape
 import com.svenjacobs.reveal.demo.ui.theme.DemoTheme
@@ -115,11 +115,15 @@ fun MainScreen(modifier: Modifier = Modifier) {
 private fun RevealOverlayScope.RevealOverlayContent(key: Key) {
 	when (key) {
 		Keys.Fab -> OverlayText(
-			modifier = Modifier.align(RevealOverlayAlignment.Start),
+			modifier = Modifier.align(
+				horizontalArrangement = RevealOverlayArrangement.Horizontal.Start,
+			),
 			text = "Click button to get started",
 		)
 		Keys.Explanation -> OverlayText(
-			modifier = Modifier.align(RevealOverlayAlignment.Bottom),
+			modifier = Modifier.align(
+				verticalArrangement = RevealOverlayArrangement.Vertical.Bottom,
+			),
 			text = "Actually we already started. This was an example of the reveal effect.",
 		)
 	}

--- a/reveal-core/build.gradle.kts
+++ b/reveal-core/build.gradle.kts
@@ -38,6 +38,7 @@ android {
 
 	kotlinOptions {
 		jvmTarget = "11"
+		freeCompilerArgs += "-Xexplicit-api=strict"
 	}
 
 	buildFeatures {

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Key.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Key.kt
@@ -1,3 +1,3 @@
 package com.svenjacobs.reveal
 
-typealias Key = Any
+public typealias Key = Any

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Reveal.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Reveal.kt
@@ -76,7 +76,7 @@ import kotlin.contracts.contract
  * @see RevealOverlayScope
  */
 @Composable
-fun Reveal(
+public fun Reveal(
 	onRevealableClick: (key: Key) -> Unit,
 	onOverlayClick: (key: Key) -> Unit,
 	modifier: Modifier = Modifier,

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealOverlay.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealOverlay.kt
@@ -9,15 +9,15 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 
-object RevealOverlayArrangement {
+public object RevealOverlayArrangement {
 
-	sealed interface Horizontal {
+	public sealed interface Horizontal {
 
 		/**
 		 * Returns an [IntRect] which represents the position and size of the overlay layout area
 		 * for a [revealable] within available [space].
 		 */
-		fun arrange(
+		public fun arrange(
 			revealable: IntRect,
 			space: IntSize,
 			confineHeight: Boolean,
@@ -26,12 +26,12 @@ object RevealOverlayArrangement {
 		/**
 		 * Returns an [IntOffset] to place the overlay content with [size] in available [layout].
 		 */
-		fun align(
+		public fun align(
 			size: IntSize,
 			layout: IntRect,
 		): IntOffset
 
-		object Start : Horizontal {
+		public object Start : Horizontal {
 
 			override fun arrange(
 				revealable: IntRect,
@@ -48,7 +48,7 @@ object RevealOverlayArrangement {
 				IntOffset(x = layout.right - size.width, y = 0)
 		}
 
-		object End : Horizontal {
+		public object End : Horizontal {
 
 			override fun arrange(
 				revealable: IntRect,
@@ -66,13 +66,13 @@ object RevealOverlayArrangement {
 		}
 	}
 
-	sealed interface Vertical {
+	public sealed interface Vertical {
 
 		/**
 		 * Returns an [IntRect] which represents the position and size of the overlay layout area
 		 * for a [revealable] within available [space].
 		 */
-		fun arrange(
+		public fun arrange(
 			revealable: IntRect,
 			space: IntSize,
 			confineWidth: Boolean,
@@ -81,12 +81,12 @@ object RevealOverlayArrangement {
 		/**
 		 * Returns an [IntOffset] to place the overlay content with [size] in available [layout].
 		 */
-		fun align(
+		public fun align(
 			size: IntSize,
 			layout: IntRect,
 		): IntOffset
 
-		object Top : Vertical {
+		public object Top : Vertical {
 
 			override fun arrange(
 				revealable: IntRect,
@@ -109,7 +109,7 @@ object RevealOverlayArrangement {
 			)
 		}
 
-		object Bottom : Vertical {
+		public object Bottom : Vertical {
 
 			override fun arrange(
 				revealable: IntRect,
@@ -141,7 +141,7 @@ object RevealOverlayArrangement {
  * @see align
  */
 @Immutable
-interface RevealOverlayScope {
+public interface RevealOverlayScope {
 
 	/**
 	 * Aligns the element horizontally either to the start or end of the reveal area.
@@ -159,7 +159,7 @@ interface RevealOverlayScope {
 	 *
 	 * @see RevealOverlayArrangement.Horizontal
 	 */
-	fun Modifier.align(
+	public fun Modifier.align(
 		horizontalArrangement: RevealOverlayArrangement.Horizontal,
 		verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
 		confineHeight: Boolean = true,
@@ -181,7 +181,7 @@ interface RevealOverlayScope {
 	 *
 	 * @see RevealOverlayArrangement.Vertical
 	 */
-	fun Modifier.align(
+	public fun Modifier.align(
 		verticalArrangement: RevealOverlayArrangement.Vertical,
 		horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
 		confineWidth: Boolean = true,

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealOverlay.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealOverlay.kt
@@ -1,19 +1,141 @@
 package com.svenjacobs.reveal
 
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.Stable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 
-// TODO: Should become classes with alignment logic in an align() method
-enum class RevealOverlayAlignment {
-	Start, Top, End, Bottom,
+object RevealOverlayArrangement {
+
+	sealed interface Horizontal {
+
+		/**
+		 * Returns an [IntRect] which represents the position and size of the overlay layout area
+		 * for a [revealable] within available [space].
+		 */
+		fun arrange(
+			revealable: IntRect,
+			space: IntSize,
+			confineHeight: Boolean,
+		): IntRect
+
+		/**
+		 * Returns an [IntOffset] to place the overlay content with [size] in available [layout].
+		 */
+		fun align(
+			size: IntSize,
+			layout: IntRect,
+		): IntOffset
+
+		object Start : Horizontal {
+
+			override fun arrange(
+				revealable: IntRect,
+				space: IntSize,
+				confineHeight: Boolean,
+			): IntRect = IntRect(
+				left = 0,
+				top = if (confineHeight) revealable.top else 0,
+				right = revealable.left,
+				bottom = if (confineHeight) revealable.bottom else space.height,
+			)
+
+			override fun align(size: IntSize, layout: IntRect): IntOffset =
+				IntOffset(x = layout.right - size.width, y = 0)
+		}
+
+		object End : Horizontal {
+
+			override fun arrange(
+				revealable: IntRect,
+				space: IntSize,
+				confineHeight: Boolean,
+			): IntRect = IntRect(
+				left = revealable.right,
+				top = if (confineHeight) revealable.top else 0,
+				right = space.width,
+				bottom = if (confineHeight) revealable.bottom else space.height,
+			)
+
+			override fun align(size: IntSize, layout: IntRect): IntOffset =
+				IntOffset(x = layout.left, y = 0)
+		}
+	}
+
+	sealed interface Vertical {
+
+		/**
+		 * Returns an [IntRect] which represents the position and size of the overlay layout area
+		 * for a [revealable] within available [space].
+		 */
+		fun arrange(
+			revealable: IntRect,
+			space: IntSize,
+			confineWidth: Boolean,
+		): IntRect
+
+		/**
+		 * Returns an [IntOffset] to place the overlay content with [size] in available [layout].
+		 */
+		fun align(
+			size: IntSize,
+			layout: IntRect,
+		): IntOffset
+
+		object Top : Vertical {
+
+			override fun arrange(
+				revealable: IntRect,
+				space: IntSize,
+				confineWidth: Boolean,
+			): IntRect =
+				IntRect(
+					left = if (confineWidth) revealable.left else 0,
+					top = 0,
+					right = if (confineWidth) revealable.right else space.width,
+					bottom = revealable.top,
+				)
+
+			override fun align(
+				size: IntSize,
+				layout: IntRect,
+			): IntOffset = IntOffset(
+				x = 0,
+				y = layout.bottom - size.height,
+			)
+		}
+
+		object Bottom : Vertical {
+
+			override fun arrange(
+				revealable: IntRect,
+				space: IntSize,
+				confineWidth: Boolean,
+			): IntRect =
+				IntRect(
+					left = if (confineWidth) revealable.left else 0,
+					top = revealable.bottom,
+					right = if (confineWidth) revealable.right else space.width,
+					bottom = space.height,
+				)
+
+			override fun align(
+				size: IntSize,
+				layout: IntRect,
+			): IntOffset = IntOffset(
+				x = 0,
+				y = layout.top,
+			)
+		}
+	}
 }
 
 /**
- * Scope for overlay content which provides a Modifier to align an element relative to the
+ * Scope for overlay content which provides Modifiers to align an element relative to the
  * reveal area.
  *
  * @see align
@@ -22,60 +144,117 @@ enum class RevealOverlayAlignment {
 interface RevealOverlayScope {
 
 	/**
-	 * Aligns the element either to the start, top, end or bottom of the reveal area.
+	 * Aligns the element horizontally either to the start or end of the reveal area.
+	 * Additionally the element is vertically aligned in relation to the reveal area via
+	 * [verticalAlignment]. Set [confineHeight] to `false` to not confine the height to the height
+	 * of the reveal area. For instance use it with a vertical alignment of [Alignment.Top] to
+	 * implement a custom alignment.
 	 *
 	 * Should be one of the first modifiers applied to the element so that other modifiers are
 	 * applied after the element was positioned.
 	 *
-	 * @see RevealOverlayAlignment
+	 * @param horizontalArrangement Horizontal arrangement (start, end)
+	 * @param verticalAlignment Vertical alignment of element in relation to reveal area
+	 * @param confineHeight Confine height of element to height of reveal area
+	 *
+	 * @see RevealOverlayArrangement.Horizontal
 	 */
-	@Stable
-	fun Modifier.align(alignment: RevealOverlayAlignment): Modifier
+	fun Modifier.align(
+		horizontalArrangement: RevealOverlayArrangement.Horizontal,
+		verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+		confineHeight: Boolean = true,
+	): Modifier
+
+	/**
+	 * Aligns the element vertically either to the top or bottom of the reveal area.
+	 * Additionally the element is horizontally aligned in relation to the reveal area via
+	 * [horizontalAlignment]. Set [confineWidth] to `false` to not confine the width to the width
+	 * of the reveal area. For instance use it with a horizontal alignment of [Alignment.Start] to
+	 * implement a custom alignment.
+	 *
+	 * Should be one of the first modifiers applied to the element so that other modifiers are
+	 * applied after the element was positioned.
+	 *
+	 * @param verticalArrangement Vertical arrangement (top, bottom)
+	 * @param horizontalAlignment Horizontal alignment in relation to reveal area
+	 * @param confineWidth Confine width of element to width of reveal area
+	 *
+	 * @see RevealOverlayArrangement.Vertical
+	 */
+	fun Modifier.align(
+		verticalArrangement: RevealOverlayArrangement.Vertical,
+		horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+		confineWidth: Boolean = true,
+	): Modifier
 }
 
 internal class RevealOverlayScopeInstance(
 	private val revealRect: IntRect,
 ) : RevealOverlayScope {
 
-	override fun Modifier.align(alignment: RevealOverlayAlignment): Modifier = this.then(
+	override fun Modifier.align(
+		horizontalArrangement: RevealOverlayArrangement.Horizontal,
+		verticalAlignment: Alignment.Vertical,
+		confineHeight: Boolean,
+	): Modifier = this.then(
 		Modifier.layout { measurable, constraints ->
-			val placeable = measurable.measure(constraints)
-			layout(constraints.maxWidth, constraints.maxHeight) {
-				val horizontalCenterX =
-					revealRect.left + (revealRect.width - placeable.width) / 2
-				val verticalCenterY =
-					revealRect.top + (revealRect.height - placeable.height) / 2
+			val layoutSize = horizontalArrangement.arrange(
+				revealable = revealRect,
+				space = IntSize(
+					width = constraints.maxWidth,
+					height = constraints.maxHeight,
+				),
+				confineHeight = confineHeight,
+			)
+			val placeable = measurable.measure(
+				constraints.copy(maxWidth = layoutSize.width),
+			)
 
-				val actualAlignment = when {
-					layoutDirection == LayoutDirection.Rtl &&
-						alignment == RevealOverlayAlignment.Start -> RevealOverlayAlignment.End
-					layoutDirection == LayoutDirection.Rtl &&
-						alignment == RevealOverlayAlignment.End -> RevealOverlayAlignment.Start
-					else -> alignment
-				}
+			layout(placeable.width, placeable.height) {
+				placeable.placeRelative(
+					x = horizontalArrangement.align(
+						size = IntSize(placeable.width, placeable.height),
+						layout = layoutSize,
+					).x,
+					y = layoutSize.top + verticalAlignment.align(
+						size = placeable.height,
+						space = layoutSize.height,
+					),
+				)
+			}
+		},
+	)
 
-				when (actualAlignment) {
-					RevealOverlayAlignment.Start ->
-						placeable.place(
-							x = revealRect.left - placeable.width,
-							y = verticalCenterY,
-						)
-					RevealOverlayAlignment.Top ->
-						placeable.place(
-							x = horizontalCenterX,
-							y = revealRect.top - placeable.height,
-						)
-					RevealOverlayAlignment.End ->
-						placeable.place(
-							x = revealRect.right,
-							y = verticalCenterY,
-						)
-					RevealOverlayAlignment.Bottom ->
-						placeable.place(
-							x = horizontalCenterX,
-							y = revealRect.bottom,
-						)
-				}
+	override fun Modifier.align(
+		verticalArrangement: RevealOverlayArrangement.Vertical,
+		horizontalAlignment: Alignment.Horizontal,
+		confineWidth: Boolean,
+	): Modifier = this.then(
+		Modifier.layout { measurable, constraints ->
+			val layoutSize = verticalArrangement.arrange(
+				revealable = revealRect,
+				space = IntSize(
+					width = constraints.maxWidth,
+					height = constraints.maxHeight,
+				),
+				confineWidth = confineWidth,
+			)
+			val placeable = measurable.measure(
+				constraints.copy(maxHeight = layoutSize.height),
+			)
+
+			layout(placeable.width, placeable.height) {
+				placeable.placeRelative(
+					x = layoutSize.left + horizontalAlignment.align(
+						size = placeable.width,
+						space = layoutSize.width,
+						layoutDirection = LayoutDirection.Ltr, // Ltr because we use placeRelative()
+					),
+					y = verticalArrangement.align(
+						size = IntSize(placeable.width, placeable.height),
+						layout = layoutSize,
+					).y,
+				)
 			}
 		},
 	)

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealScope.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealScope.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.unit.dp
  * Scope inside [Reveal]'s contents which provides [revealable] modifier.
  */
 @Immutable
-interface RevealScope {
+public interface RevealScope {
 
 	/**
 	 * Registers the element as a revealable item.
@@ -25,7 +25,7 @@ interface RevealScope {
 	 * @param shape   Shape of the reveal effect around the element. Defaults to a rounded rect
 	 *                with a corner size of 4 dp.
 	 */
-	fun Modifier.revealable(
+	public fun Modifier.revealable(
 		key: Key,
 		padding: PaddingValues = PaddingValues(8.dp),
 		shape: RevealShape = RevealShape.RoundRect(4.dp),

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealShape.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealShape.kt
@@ -7,13 +7,13 @@ import androidx.compose.ui.unit.Dp
  *
  * TODO: Shapes should draw themselves via a draw() method
  */
-sealed interface RevealShape {
+public sealed interface RevealShape {
 
-	object Rect : RevealShape
+	public object Rect : RevealShape
 
-	object Circle : RevealShape
+	public object Circle : RevealShape
 
-	data class RoundRect(
+	public data class RoundRect(
 		val cornerSize: Dp,
 	) : RevealShape
 }

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealState.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealState.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 @Stable
-class RevealState {
+public class RevealState {
 
 	private val mutex = Mutex()
 
@@ -20,7 +20,7 @@ class RevealState {
 		private set
 	private val revealables: MutableMap<Key, Revealable> = mutableMapOf()
 
-	suspend fun reveal(key: Key) {
+	public suspend fun reveal(key: Key) {
 		mutex.withLock {
 			// TODO: hide when key was not found?
 			currentRevealable = revealables[key]
@@ -28,7 +28,7 @@ class RevealState {
 		}
 	}
 
-	suspend fun hide() {
+	public suspend fun hide() {
 		mutex.withLock {
 			visible = false
 		}
@@ -40,4 +40,4 @@ class RevealState {
 }
 
 @Composable
-fun rememberRevealState() = remember { RevealState() }
+public fun rememberRevealState(): RevealState = remember { RevealState() }


### PR DESCRIPTION
This pull requests greatly improves the `align` modifier based on the feedback by @owenlejeune (#5).

Alignment is now split into two modifiers: one for horizontal and one for vertical alignment. Additionally the overlay content can be vertically or horizontally aligned in relation to the reveal area. If the new `confineWidth` or `confineHeight` parameters are set to `false`, the overlay content's width/height is not confined to the reveal width/height. This in conjunction with for example a horizontal alignment of `Start` and a `Box` as a container for the overlay content allows a more custom alignment, if required.

