### PR TITLE
fix: Fix broken hide animation

### DIFF
--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Reveal.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Reveal.kt
@@ -88,6 +88,11 @@ public fun Reveal(
 	val animatedOverlayContentAlpha by animateFloatAsState(
 		targetValue = if (revealState.isVisible) 1.0f else 0.0f,
 		animationSpec = overlayContentAnimationSpec,
+		finishedListener = { alpha ->
+			if (alpha == 0.0f) {
+				revealState.onHideAnimationFinished()
+			}
+		},
 	)
 	var layoutCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
 	val positionInRoot by remember {

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealState.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealState.kt
@@ -42,9 +42,12 @@ public class RevealState internal constructor(
 
 	public suspend fun hide() {
 		mutex.withLock {
-			currentRevealable = null
 			visible = false
 		}
+	}
+
+	internal fun onHideAnimationFinished() {
+		currentRevealable = null
 	}
 
 	internal fun putRevealable(revealable: Revealable) {


### PR DESCRIPTION
`currentRevealable` must be set to `null` only after the fade out animation is finished or else the animation won't occur at all.