### PR TITLE
feat: Add Balloon variant with Brush support

### DIFF
--- a/demo-android/src/main/kotlin/com/svenjacobs/reveal/demo/ui/MainScreen.kt
+++ b/demo-android/src/main/kotlin/com/svenjacobs/reveal/demo/ui/MainScreen.kt
@@ -137,7 +137,7 @@ private fun OverlayText(text: String, arrow: Arrow, modifier: Modifier = Modifie
 	Balloon(
 		modifier = modifier.padding(8.dp),
 		arrow = arrow,
-		color = MaterialTheme.colorScheme.secondaryContainer,
+		backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
 		elevation = 2.dp,
 	) {
 		Text(

--- a/reveal-shapes/src/main/kotlin/com/svenjacobs/reveal/shapes/balloon/Balloon.kt
+++ b/reveal-shapes/src/main/kotlin/com/svenjacobs/reveal/shapes/balloon/Balloon.kt
@@ -1,5 +1,6 @@
 package com.svenjacobs.reveal.shapes.balloon
 
+import androidx.annotation.FloatRange
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Dp
@@ -15,16 +17,72 @@ import androidx.compose.ui.unit.dp
 /**
  * A balloon (speech / chat bubble) with an arrow on one side.
  *
+ * This variant specifies a [backgroundColor]. See other variant for [Brush] support.
+ *
  * @see Arrow
  */
 @Composable
 public fun Balloon(
 	arrow: Arrow,
-	color: Color,
+	backgroundColor: Color,
 	modifier: Modifier = Modifier,
 	cornerRadius: Dp = 8.dp,
 	elevation: Dp = 0.dp,
 	contentAlignment: Alignment = Alignment.TopStart,
+	content: @Composable BoxScope.() -> Unit,
+) {
+	Balloon(
+		arrow = arrow,
+		modifier = modifier,
+		backgroundModifier = Modifier.background(color = backgroundColor),
+		cornerRadius = cornerRadius,
+		elevation = elevation,
+		contentAlignment = contentAlignment,
+		content = content,
+	)
+}
+
+/**
+ * A balloon (speech / chat bubble) with an arrow on one side.
+ *
+ * This variant specifies a [backgroundBrush] and optional [backgroundAlpha]. See other variant for
+ * simple [Color] support.
+ *
+ * @see Arrow
+ */
+@Composable
+public fun Balloon(
+	arrow: Arrow,
+	backgroundBrush: Brush,
+	modifier: Modifier = Modifier,
+	@FloatRange(from = 0.0, to = 1.0) backgroundAlpha: Float = 1.0f,
+	cornerRadius: Dp = 8.dp,
+	elevation: Dp = 0.dp,
+	contentAlignment: Alignment = Alignment.TopStart,
+	content: @Composable BoxScope.() -> Unit,
+) {
+	Balloon(
+		arrow = arrow,
+		modifier = modifier,
+		backgroundModifier = Modifier.background(
+			brush = backgroundBrush,
+			alpha = backgroundAlpha,
+		),
+		cornerRadius = cornerRadius,
+		elevation = elevation,
+		contentAlignment = contentAlignment,
+		content = content,
+	)
+}
+
+@Composable
+private fun Balloon(
+	arrow: Arrow,
+	modifier: Modifier,
+	backgroundModifier: Modifier,
+	cornerRadius: Dp,
+	elevation: Dp,
+	contentAlignment: Alignment,
 	content: @Composable BoxScope.() -> Unit,
 ) {
 	Box(
@@ -38,7 +96,7 @@ public fun Balloon(
 				)
 				clip = true
 			}
-			.background(color = color)
+			.then(backgroundModifier)
 			.padding(arrow.padding),
 		contentAlignment = contentAlignment,
 		content = content,


### PR DESCRIPTION
Adds a Balloon variant with `Brush` support for greater flexibility of background rendering.