### PR TITLE
feat: Make putRevealable() and removeRevealable() public

### DIFF
--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Reveal.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Reveal.kt
@@ -125,7 +125,7 @@ public fun Reveal(
 				detectTapGestures(
 					onPress = { offset ->
 						rev?.key?.let(
-							if (rev?.revealArea?.contains(offset) == true) {
+							if (rev?.area?.contains(offset) == true) {
 								onRevealableClick
 							} else {
 								onOverlayClick
@@ -149,7 +149,7 @@ public fun Reveal(
 	}
 }
 
-private fun InternalRevealable.toActual(
+private fun Revealable.toActual(
 	containerPositionInRoot: Offset,
 	density: Density,
 	layoutDirection: LayoutDirection,
@@ -157,7 +157,7 @@ private fun InternalRevealable.toActual(
 	key = key,
 	shape = shape,
 	padding = padding,
-	revealArea = getRevealArea(
+	area = computeArea(
 		containerPositionInRoot = containerPositionInRoot,
 		density = density,
 		layoutDirection = layoutDirection,

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealScope.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealScope.kt
@@ -6,7 +6,9 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toSize
 
 /**
  * Scope inside [Reveal]'s contents which provides [revealable] modifier.
@@ -48,10 +50,15 @@ internal class RevealScopeInstance(
 			Modifier
 				.onGloballyPositioned { layoutCoordinates ->
 					revealState.putRevealable(
-						key = key,
-						shape = shape,
-						padding = padding,
-						layoutCoordinates = layoutCoordinates,
+						Revealable(
+							key = key,
+							shape = shape,
+							padding = padding,
+							layout = Revealable.Layout(
+								offset = layoutCoordinates.positionInRoot(),
+								size = layoutCoordinates.size.toSize(),
+							),
+						),
 					)
 				}
 				.composed {

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
@@ -105,7 +105,7 @@ private class DimItemHolder(
 				.alpha(contentAlpha.value),
 			content = {
 				RevealOverlayScopeInstance(
-					revealableRect = revealable.revealArea.toIntRect(),
+					revealableRect = revealable.area.toIntRect(),
 				).content(revealable.key)
 			},
 		)

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/effect/internal/Graphics.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/effect/internal/Graphics.kt
@@ -13,8 +13,8 @@ internal fun ActualRevealable.createShapePath(
 ): Path = shape
 	.clip(
 		size = Size(
-			width = revealArea.width,
-			height = revealArea.height,
+			width = area.width,
+			height = area.height,
 		),
 		density = density,
 		layoutDirection = layoutDirection,
@@ -22,8 +22,8 @@ internal fun ActualRevealable.createShapePath(
 	.apply {
 		translate(
 			Offset(
-				x = revealArea.left,
-				y = revealArea.top,
+				x = area.left,
+				y = area.top,
 			),
 		)
 	}


### PR DESCRIPTION
These functions can be used to add or remove revealables manually. This should only be required when working with legacy Android views, for example in an app that is gradually migrated to Compose.