### PR TITLE
feat: Always render effect fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ dependencies {
 
 ### Compose
 
-Since you probably want the reveal effect to cover the whole screen, the `Reveal` composable should
-be one of the top most composables in the hierarchy of your screen-level composable.
+The `Reveal` composable should be one of the top most composables in the hierarchy of your
+screen-level composable in order to access it's scope. However it doesn't matter where in the
+component hierarchy the composable is added. The effect is always rendered fullscreen.
 
 ```kotlin
 @Composable

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Revealable.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Revealable.kt
@@ -49,19 +49,14 @@ public data class ActualRevealable(
 /**
  * Returns [Rect] in pixels of the reveal area including padding for this [Revealable].
  */
-internal fun Revealable.computeArea(
-	containerPositionInRoot: Offset,
-	density: Density,
-	layoutDirection: LayoutDirection,
-): Rect {
-	val pos = layout.offset - containerPositionInRoot
-	return with(density) {
+internal fun Revealable.computeArea(density: Density, layoutDirection: LayoutDirection): Rect =
+	with(density) {
 		val rect = Rect(
-			left = pos.x - padding.calculateLeftPadding(layoutDirection).toPx(),
-			top = pos.y - padding.calculateTopPadding().toPx(),
-			right = pos.x + padding.calculateRightPadding(layoutDirection).toPx() +
+			left = layout.offset.x - padding.calculateLeftPadding(layoutDirection).toPx(),
+			top = layout.offset.y - padding.calculateTopPadding().toPx(),
+			right = layout.offset.x + padding.calculateRightPadding(layoutDirection).toPx() +
 				layout.size.width,
-			bottom = pos.y + padding.calculateBottomPadding().toPx() +
+			bottom = layout.offset.y + padding.calculateBottomPadding().toPx() +
 				layout.size.height,
 		)
 
@@ -71,4 +66,3 @@ internal fun Revealable.computeArea(
 			rect
 		}
 	}
-}

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/internal/fullscreen/Fullscreen.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/internal/fullscreen/Fullscreen.kt
@@ -1,0 +1,52 @@
+package com.svenjacobs.reveal.internal.fullscreen
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCompositionContext
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Places [content] in a new [ComposeView] which is added to the root content view, hence
+ * content is rendered above all other views.
+ */
+@Composable
+internal fun Fullscreen(content: @Composable () -> Unit) {
+	val context = LocalContext.current
+	val compositionContext = rememberCompositionContext()
+	val composeView = remember {
+		ComposeView(context).apply {
+			id = View.generateViewId()
+			layoutParams = ViewGroup.LayoutParams(
+				ViewGroup.LayoutParams.MATCH_PARENT,
+				ViewGroup.LayoutParams.MATCH_PARENT,
+			)
+			setParentCompositionContext(compositionContext)
+			setContent(content)
+		}
+	}
+
+	DisposableEffect(Unit) {
+		val container =
+			context.findActivity()?.window?.decorView?.findViewById<ViewGroup>(android.R.id.content)
+				?: throw IllegalStateException("Root content view with ID android.R.id.content not found")
+
+		container.addView(composeView)
+
+		onDispose {
+			container.removeView(composeView)
+		}
+	}
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+	is Activity -> this
+	is ContextWrapper -> baseContext.findActivity()
+	else -> null
+}


### PR DESCRIPTION
This pull requests significantly changes the behaviour of Reveal!

Reveal now internally adds a new `ComposeView` to Android's root content view for the fullscreen effect. Therefore it doesn't matter anymore where the `Reveal` composable is added.

This change improves Reveal's usability especially in multi-module applications, where Reveal is used in different, independent features. A single `Reveal` root composable is not required anymore.