### PR TITLE
fix: Revealables not updating after recomposition

### DIFF
--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Revealable.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Revealable.kt
@@ -25,17 +25,6 @@ public data class Revealable(
 		val offset: Offset,
 		val size: Size,
 	)
-
-	override fun equals(other: Any?): Boolean {
-		if (this === other) return true
-		if (other !is Revealable) return false
-
-		if (key != other.key) return false
-
-		return true
-	}
-
-	override fun hashCode(): Int = key.hashCode()
 }
 
 @Immutable


### PR DESCRIPTION
Fixes a bug where revealables where not updated after a recomposition. For example when a Composable was added or removed from the UI hierarchy which resulted in a new position of the revealable item, the effect was still highlighting the old position.

![Screenshot_20230308_144511](https://user-images.githubusercontent.com/255313/223738178-17d9582f-efef-4dd6-820a-90c5670adcc7.png)

The reason was that the custom implementation of `equals` and `hashCode` of the `Revealable` data class caused the internal map not updating an item when only the offset changed.