### PR TITLE
feat: Add revealable() modifiers with multiple keys

### DIFF
--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealScope.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealScope.kt
@@ -39,6 +39,54 @@ public interface RevealScope {
 		shape: RevealShape = RevealShape.RoundRect(4.dp),
 		padding: PaddingValues = PaddingValues(8.dp),
 	): Modifier
+
+	/**
+	 * Registers the element as a revealable item.
+	 *
+	 * Each key in [keys] must be unique in the current scope and should be used for
+	 * [RevealState.reveal]. Internally [Modifier.onGloballyPositioned] is used. Hence elements are
+	 * only registered after they have been laid out.
+	 *
+	 * If the element that this modifier is applied to leaves the composition while the reveal
+	 * effect is shown for the element, the effect is finished.
+	 *
+	 * @param keys    Unique keys to identify the revealable content. Also see documentation of [Key].
+	 * @param shape   Shape of the reveal effect around the element. Defaults to a rounded rect
+	 *                with a corner size of 4 dp.
+	 * @param padding Additional padding around the reveal area. Positive values increase area while
+	 *                negative values decrease it. Defaults to 8 dp on all sides.
+	 *
+	 * @see Key
+	 */
+	public fun Modifier.revealable(
+		vararg keys: Key,
+		shape: RevealShape = RevealShape.RoundRect(4.dp),
+		padding: PaddingValues = PaddingValues(8.dp),
+	): Modifier
+
+	/**
+	 * Registers the element as a revealable item.
+	 *
+	 * Each key specified in [keys] must be unique in the current scope and should be used for
+	 * [RevealState.reveal]. Internally [Modifier.onGloballyPositioned] is used. Hence elements are
+	 * only registered after they have been laid out.
+	 *
+	 * If the element that this modifier is applied to leaves the composition while the reveal
+	 * effect is shown for the element, the effect is finished.
+	 *
+	 * @param keys    Unique keys to identify the revealable content. Also see documentation of [Key].
+	 * @param shape   Shape of the reveal effect around the element. Defaults to a rounded rect
+	 *                with a corner size of 4 dp.
+	 * @param padding Additional padding around the reveal area. Positive values increase area while
+	 *                negative values decrease it. Defaults to 8 dp on all sides.
+	 *
+	 * @see Key
+	 */
+	public fun Modifier.revealable(
+		keys: Iterable<Key>,
+		shape: RevealShape = RevealShape.RoundRect(4.dp),
+		padding: PaddingValues = PaddingValues(8.dp),
+	): Modifier
 }
 
 internal class RevealScopeInstance(
@@ -46,9 +94,30 @@ internal class RevealScopeInstance(
 ) : RevealScope {
 
 	override fun Modifier.revealable(key: Key, shape: RevealShape, padding: PaddingValues): Modifier =
-		this.then(
-			Modifier
-				.onGloballyPositioned { layoutCoordinates ->
+		revealable(
+			keys = listOf(key),
+			shape = shape,
+			padding = padding,
+		)
+
+	override fun Modifier.revealable(
+		vararg keys: Key,
+		shape: RevealShape,
+		padding: PaddingValues,
+	): Modifier = revealable(
+		keys = keys.toList(),
+		shape = shape,
+		padding = padding,
+	)
+
+	override fun Modifier.revealable(
+		keys: Iterable<Key>,
+		shape: RevealShape,
+		padding: PaddingValues,
+	): Modifier = this.then(
+		Modifier
+			.onGloballyPositioned { layoutCoordinates ->
+				for (key in keys) {
 					revealState.putRevealable(
 						Revealable(
 							key = key,
@@ -61,13 +130,16 @@ internal class RevealScopeInstance(
 						),
 					)
 				}
-				.composed {
-					DisposableEffect(Unit) {
-						onDispose {
+			}
+			.composed {
+				DisposableEffect(Unit) {
+					onDispose {
+						for (key in keys) {
 							revealState.removeRevealable(key)
 						}
 					}
-					this
-				},
-		)
+				}
+				this
+			},
+	)
 }


### PR DESCRIPTION
Sometimes the same UI element should be revealed with different overlay contents. This is already possible by applying the `revealable()` modifier multiple times with different keys. The PR simplifies this by providing `reveable()` modifiers with multiple keys.

Closes #26 