### PR TITLE
fix: Remove toSet() which always produces new set instance

### DIFF
--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealState.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealState.kt
@@ -114,7 +114,7 @@ public class RevealState internal constructor(
 	/**
 	 * Removes a [Revealable] from this state.
 	 *
-	 * Usually this must not be called manually. The [RevealScope.revealable] modifier takes care
+	 * Usually this should not be called manually. The [RevealScope.revealable] modifier takes care
 	 * of removing revealables when the composable is disposed.
 	 */
 	public fun removeRevealable(key: Key) {

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealState.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/RevealState.kt
@@ -57,7 +57,7 @@ public class RevealState internal constructor(
 	 * Can be used to query when a revealable was registered via [RevealScope.revealable].
 	 */
 	public val revealableKeys: Set<Key>
-		get() = revealables.keys.toSet()
+		get() = revealables.keys
 
 	/**
 	 * Reveals revealable with given [key]


### PR DESCRIPTION
`toSet()` always produces a new `Set` instance when the underlying `revealables` `Map` changes, even if the keys did not change. This could lead to an endless recomposition bug if for example `revealableKeys` is observed in a `LaunchedEffect`.