### PR TITLE
fix: Graphics glitch on Android <= 9 when rendering cutout

### DIFF
--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
@@ -122,8 +122,9 @@ private class DimItemHolder(
 
 		drawPath(
 			path,
-			Color.Transparent.copy(alpha = 1.0f - contentAlpha.value),
-			blendMode = BlendMode.DstIn,
+			Color.Black,
+			alpha = contentAlpha.value,
+			blendMode = BlendMode.DstOut,
 		)
 	}
 }


### PR DESCRIPTION
Fixes #43 

Instead of using `BlendMode.DstIn`, which introduces a graphics glitch when rendering the cutout (see #43), use `BlendMode.DstOut`.