### PR TITLE
chore: Move overlay alpha animation spec into RevealOverlayEffect interface

### DIFF
--- a/demo-android/src/main/kotlin/com/svenjacobs/reveal/demo/ui/MainScreen.kt
+++ b/demo-android/src/main/kotlin/com/svenjacobs/reveal/demo/ui/MainScreen.kt
@@ -51,8 +51,6 @@ fun MainScreen(modifier: Modifier = Modifier) {
 		val scope = rememberCoroutineScope()
 
 		Reveal(
-			modifier = modifier,
-			revealState = revealState,
 			onRevealableClick = { key ->
 				scope.launch {
 					if (key == Keys.Fab) {
@@ -63,6 +61,8 @@ fun MainScreen(modifier: Modifier = Modifier) {
 				}
 			},
 			onOverlayClick = { scope.launch { revealState.hide() } },
+			modifier = modifier,
+			revealState = revealState,
 			overlayInserter = InPlaceRevealOverlayInserter(),
 			overlayContent = { key -> RevealOverlayContent(key) },
 		) {

--- a/reveal-core/src/androidTest/kotlin/com/svenjacobs/reveal/BaseRevealTest.kt
+++ b/reveal-core/src/androidTest/kotlin/com/svenjacobs/reveal/BaseRevealTest.kt
@@ -32,9 +32,9 @@ public abstract class BaseRevealTest {
 			revealState = rememberRevealState()
 
 			Reveal(
-				revealState = revealState,
 				onRevealableClick = onRevealableClick,
 				onOverlayClick = onOverlayClick,
+				revealState = revealState,
 				overlayContent = { key ->
 					when (key) {
 						Keys.Key1 -> Text("Overlay1")

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Reveal.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/Reveal.kt
@@ -1,8 +1,6 @@
 package com.svenjacobs.reveal
 
-import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -31,9 +29,9 @@ import com.svenjacobs.reveal.effect.dim.DimRevealOverlayEffect
  *
  * When active, applies the [overlayEffect] and only reveals current revealable element.
  *
- * Adds a new `ComposeView` to the root content view (`android.R.id.content`) for the fullscreen
- * effect. Therefore it does not matter where in the component hierarchy this composable is added.
- * The effect is always rendered fullscreen.
+ * When [FullscreenRevealOverlayInserter] is used, adds a new `ComposeView` to the root content
+ * view (`android.R.id.content`) for the fullscreen effect. Therefore it does not matter where in
+ * the component hierarchy this composable is added. The effect is always rendered fullscreen.
  *
  * Elements inside the contents of this composable are registered as "revealables" via the
  * [RevealScope.revealable] modifier in the scope of the [content] composable.
@@ -44,30 +42,29 @@ import com.svenjacobs.reveal.effect.dim.DimRevealOverlayEffect
  * images) next to the reveal area. This content is placed above the greyed out backdrop. Elements
  * in this scope can be aligned relative to the reveal area via [RevealOverlayScope.align].
  *
- * @param onRevealableClick          Called when the revealable area was clicked, where the
- *                                   parameter `key` is the key of the current revealable item.
- * @param onOverlayClick             Called when the overlay is clicked somewhere outside of the
- *                                   current revealable, where the parameter `key` is the key of the
- *                                   current revealable.
- * @param modifier                   Modifier applied to this composable.
- * @param revealState                State which controls the visibility of the reveal effect.
- * @param overlayEffect              The effect which is used for the background and reveal of
- *                                   items. Currently only [DimRevealOverlayEffect] is supported.
- * @param overlayEffectAnimationSpec Animation spec for the animated alpha value of the overlay
- *                                   effect when showing or hiding.
- * @param overlayInserter            Strategy of how to insert the overlay into the composition.
- * @param overlayContent             Optional content which is placed above the overlay and where
- *                                   its elements can be aligned relative to the reveal area via
- *                                   modifiers available in the scope of this composable. The `key`
- *                                   parameter is the key of the current visible revealable item.
- * @param content                    Actual content which is visible when the Reveal composable is
- *                                   not active. Elements are registered as revealables via
- *                                   modifiers provided in the scope of this composable.
+ * @param onRevealableClick  Called when the revealable area was clicked, where the parameter `key`
+ *                           is the key of the current revealable item.
+ * @param onOverlayClick     Called when the overlay is clicked somewhere outside of the current
+ *                           revealable, where the parameter `key` is the key of the current
+ *                           revealable.
+ * @param modifier           Modifier applied to this composable.
+ * @param revealState        State which controls the visibility of the reveal effect.
+ * @param overlayEffect      The effect which is used for the background and reveal of items.
+ *                           Currently only [DimRevealOverlayEffect] is supported.
+ * @param overlayInserter    Strategy of how to insert the overlay into the composition.
+ * @param overlayContent     Optional content which is placed above the overlay and where its
+ *                           elements can be aligned relative to the reveal area via modifiers
+ *                           available in the scope of this composable. The `key` parameter is the
+ *                           key of the current visible revealable item.
+ * @param content            Actual content which is visible when the Reveal composable is not
+ *                           active. Elements are registered as revealables via modifiers provided
+ *                           in the scope of this composable.
  *
  * @see RevealState
  * @see RevealScope
  * @see RevealOverlayScope
  * @see DimRevealOverlayEffect
+ * @see RevealOverlayInserter
  */
 @Composable
 public fun Reveal(
@@ -76,14 +73,13 @@ public fun Reveal(
 	modifier: Modifier = Modifier,
 	revealState: RevealState = rememberRevealState(),
 	overlayEffect: RevealOverlayEffect = DimRevealOverlayEffect(),
-	overlayEffectAnimationSpec: AnimationSpec<Float> = tween(durationMillis = 500),
 	overlayInserter: RevealOverlayInserter = FullscreenRevealOverlayInserter(),
-	overlayContent: @Composable RevealOverlayScope.(key: Key) -> Unit = {},
-	content: @Composable RevealScope.() -> Unit,
+	overlayContent: @Composable (RevealOverlayScope.(key: Key) -> Unit) = {},
+	content: @Composable (RevealScope.() -> Unit),
 ) {
 	val animatedOverlayAlpha by animateFloatAsState(
 		targetValue = if (revealState.isVisible) 1.0f else 0.0f,
-		animationSpec = overlayEffectAnimationSpec,
+		animationSpec = overlayEffect.alphaAnimationSpec,
 		finishedListener = { alpha ->
 			if (alpha == 0.0f) {
 				revealState.onHideAnimationFinished()
@@ -178,7 +174,6 @@ public fun Reveal(
 	modifier: Modifier = Modifier,
 	revealState: RevealState = rememberRevealState(),
 	overlayEffect: RevealOverlayEffect = DimRevealOverlayEffect(),
-	overlayEffectAnimationSpec: AnimationSpec<Float> = tween(durationMillis = 500),
 	overlayContent: @Composable RevealOverlayScope.(key: Key) -> Unit = {},
 	content: @Composable RevealScope.() -> Unit,
 ): Unit = Reveal(
@@ -187,7 +182,6 @@ public fun Reveal(
 	modifier = modifier,
 	revealState = revealState,
 	overlayEffect = overlayEffect,
-	overlayEffectAnimationSpec = overlayEffectAnimationSpec,
 	overlayInserter = FullscreenRevealOverlayInserter(revealableOffset),
 	overlayContent = overlayContent,
 	content = content,

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/effect/RevealOverlayEffect.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/effect/RevealOverlayEffect.kt
@@ -1,5 +1,6 @@
 package com.svenjacobs.reveal.effect
 
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
@@ -21,4 +22,9 @@ public interface RevealOverlayEffect {
 		modifier: Modifier,
 		content: @Composable RevealOverlayScope.(key: Key) -> Unit,
 	)
+
+	/**
+	 * Animation spec for the animated alpha of the overlay when this effect is shown or hidden.
+	 */
+	public val alphaAnimationSpec: AnimationSpec<Float>
 }

--- a/reveal-core/src/main/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
+++ b/reveal-core/src/main/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
@@ -36,13 +36,17 @@ import com.svenjacobs.reveal.internal.rect.toIntRect
 /**
  * An overlay effect which dims the background as specified via [color].
  *
- * @param color                Background color of the overlay.
- * @param contentAnimationSpec Animation spec for the animated alpha value of the overlay content.
+ * @param alphaAnimationSpec        Animation spec for the animated alpha of the overlay when this
+ *                                  effect is shown or hidden.
+ * @param color                     Background color of the overlay.
+ * @param contentAlphaAnimationSpec Animation spec for the animated alpha value of the overlay
+ *                                  content.
  */
 @Immutable
 public class DimRevealOverlayEffect(
+	override val alphaAnimationSpec: AnimationSpec<Float> = tween(durationMillis = 500),
 	private val color: Color = Color.Black.copy(alpha = 0.8f),
-	private val contentAnimationSpec: AnimationSpec<Float> = tween(durationMillis = 500),
+	private val contentAlphaAnimationSpec: AnimationSpec<Float> = tween(durationMillis = 500),
 ) : RevealOverlayEffect {
 
 	@Composable
@@ -58,7 +62,7 @@ public class DimRevealOverlayEffect(
 				revealable = it,
 				fromState = Gone,
 				toState = Visible,
-				contentAnimationSpec = contentAnimationSpec,
+				contentAlphaAnimationSpec = contentAlphaAnimationSpec,
 			)
 		}
 
@@ -67,7 +71,7 @@ public class DimRevealOverlayEffect(
 				revealable = it,
 				fromState = Visible,
 				toState = Gone,
-				contentAnimationSpec = contentAnimationSpec,
+				contentAlphaAnimationSpec = contentAlphaAnimationSpec,
 			)
 		}
 
@@ -136,12 +140,13 @@ private fun rememberDimItemHolder(
 	revealable: ActualRevealable,
 	fromState: DimItemState,
 	toState: DimItemState,
-	contentAnimationSpec: AnimationSpec<Float>,
+	contentAlphaAnimationSpec: AnimationSpec<Float>,
 ): DimItemHolder = key(revealable.key) {
 	val targetState = remember { mutableStateOf(fromState) }
 	val contentAlpha = animateFloatAsState(
 		targetValue = if (targetState.value == Visible) 1.0f else 0.0f,
-		animationSpec = contentAnimationSpec,
+		animationSpec = contentAlphaAnimationSpec,
+		label = "contentAlpha",
 	)
 
 	LaunchedEffect(Unit) {


### PR DESCRIPTION
Moves the content alpha animation spec into the `RevealOverlayEffect` interface where it's better suited.
Unfortunately this is a breaking change where I did not find a nice deprecation / migration path.
