### PR TITLE
chore: make state class constructors public

### DIFF
--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealCanvasState.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealCanvasState.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.unit.DpOffset
  * @see rememberRevealCanvasState
  */
 @Stable
-public class RevealCanvasState internal constructor() {
+public class RevealCanvasState public constructor() {
 
 	internal var overlayContent: (@Composable () -> Unit)? by mutableStateOf(null)
 	internal var revealableOffset: DpOffset by mutableStateOf(DpOffset.Zero)

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealState.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealState.kt
@@ -19,9 +19,14 @@ import kotlinx.coroutines.sync.withLock
 @Stable
 @Suppress("MemberVisibilityCanBePrivate")
 public class RevealState internal constructor(
-	visible: Boolean = false,
-	private val restoreCurrentRevealableKey: Key? = null,
+	visible: Boolean,
+	private val restoreCurrentRevealableKey: Key?,
 ) {
+
+	public constructor() : this(
+		visible = false,
+		restoreCurrentRevealableKey = null,
+	)
 
 	private val mutex = Mutex()
 	private var didRestoreCurrentRevealable = false


### PR DESCRIPTION
This allows a more flexible usage of state classes. See [here](https://github.com/svenjacobs/reveal/issues/89#issuecomment-1985437108) for reference.