### PR TITLE
fix: downgrade runner to macOS 13

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -23,7 +23,7 @@ jobs:
 
   test:
     timeout-minutes: 30
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         api-level: [ 21, 29 ]


### PR DESCRIPTION
`macos-latest` uses macOS Sonoma with M1 where currently Android emulators don't work.

https://github.com/ReactiveCircus/android-emulator-runner/issues/392#issuecomment-2106167725