### PR TITLE
fix: reset overlay content when Reveal composable is disposed

### DIFF
--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Reveal.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Reveal.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -156,6 +157,14 @@ public fun Reveal(
 
 				else -> null
 			}
+		}
+	}
+
+	// When the Reveal composable is disposed we need to reset overlayContent or else the effect
+	// might remain on the screen (issue #196).
+	DisposableEffect(Unit) {
+		onDispose {
+			revealCanvasState.overlayContent = null
 		}
 	}
 }


### PR DESCRIPTION
Fixes #196