### PR TITLE
feat: Added multiple items reveal to the demo

### DIFF
--- a/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/presentation/MainScreen.kt
+++ b/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/presentation/MainScreen.kt
@@ -1,11 +1,16 @@
 package com.svenjacobs.reveal.android.tests.presentation
 
+import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -19,6 +24,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.svenjacobs.reveal.Key
@@ -34,7 +40,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-private enum class Keys { Fab, Explanation }
+private enum class Keys { Fab, Explanation, MultipleSelection }
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -89,6 +95,7 @@ fun MainScreen(revealCanvasState: RevealCanvasState, modifier: Modifier = Modifi
 					.padding(contentPadding)
 					.padding(horizontal = 16.dp),
 				horizontalAlignment = Alignment.CenterHorizontally,
+				verticalArrangement = Arrangement.spacedBy(16.dp),
 			) {
 				Text(
 					modifier = Modifier
@@ -97,7 +104,7 @@ fun MainScreen(revealCanvasState: RevealCanvasState, modifier: Modifier = Modifi
 							key = Keys.Explanation,
 							borderStroke = BorderStroke(2.dp, Color.DarkGray),
 							onClick = {
-								scope.launch { revealState.hide() }
+								scope.launch { revealState.reveal(Keys.MultipleSelection) }
 							},
 						),
 					text = "Reveal is a lightweight, simple reveal effect (also known as " +
@@ -105,6 +112,38 @@ fun MainScreen(revealCanvasState: RevealCanvasState, modifier: Modifier = Modifi
 					style = MaterialTheme.typography.bodyLarge,
 					textAlign = TextAlign.Justify,
 				)
+
+				Row(
+					modifier = Modifier
+						.align(Alignment.CenterHorizontally)
+						.revealable(
+							key = Keys.MultipleSelection,
+							onClick = {
+								scope.launch { revealState.hide() }
+							},
+						)
+					,
+					horizontalArrangement = Arrangement.spacedBy(16.dp),
+					verticalAlignment = Alignment.CenterVertically,
+				) {
+					val context = LocalContext.current
+					Button(
+						onClick = {
+							Toast.makeText(context, "Option 1 selected", Toast.LENGTH_SHORT).show()
+						}
+					) {
+						Text("Option 1")
+					}
+
+					Button(
+						onClick = {
+							Toast.makeText(context, "Option 1 selected", Toast.LENGTH_SHORT).show()
+						}
+					) {
+						Text("Option 2")
+					}
+				}
+
 			}
 		}
 	}
@@ -126,6 +165,14 @@ private fun RevealOverlayScope.RevealOverlayContent(key: Key) {
 				verticalArrangement = RevealOverlayArrangement.Bottom,
 			),
 			text = "Actually we already started. This was an example of the reveal effect.",
+			arrow = Arrow.top(),
+		)
+
+		Keys.MultipleSelection -> OverlayText(
+			modifier = Modifier.align(
+				verticalArrangement = RevealOverlayArrangement.Bottom,
+			),
+			text = "Pick one of the options to proceed though the app flow.",
 			arrow = Arrow.top(),
 		)
 	}


### PR DESCRIPTION
This PR adds a usecase for handling clicks on the multiple revealed elements.

![Screenshot_20250617_140030](https://github.com/user-attachments/assets/3610c485-189e-4cb2-93fe-03d830a1d7d5)
