### PR TITLE
fix: ui tests

### DIFF
--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/BaseRevealTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/BaseRevealTest.kt
@@ -1,5 +1,6 @@
 package com.svenjacobs.reveal.android.tests
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -41,6 +42,8 @@ abstract class BaseRevealTest {
 
 			RevealCanvas(revealCanvasState = revealCanvasState) {
 				Reveal(
+					// this must take full screen for correct clicks handling by test runner
+					modifier = Modifier.fillMaxSize(),
 					onRevealableClick = onRevealableClick,
 					onOverlayClick = onOverlayClick,
 					revealCanvasState = revealCanvasState,


### PR DESCRIPTION
@svenjacobs there is an issue in your test setup - the `Reveal` composable was setup to take dynamic size. 
And because of that test runner picked wrong coordinates for click (actual resize happened at the time of performing click)