### PR TITLE
chore: add Dependabot Gradle coverage for demo-app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,22 @@ updates:
           - "androidx.compose.compiler*"
         exclude-patterns:
           - "org.jetbrains.kotlinx*"
+  - package-ecosystem: "gradle"
+    directory: "/demo-app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Berlin"
+    assignees:
+      - "svenjacobs"
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "androidx.compose.compiler*"
+        exclude-patterns:
+          - "org.jetbrains.kotlinx*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- Adds a second `gradle` Dependabot entry targeting `/demo-app`
- `demo-app` is a separate Gradle project with its own `settings.gradle.kts` and was not covered by the existing root-directory scan
- Mirrors the same schedule, assignees, and Kotlin grouping config as the root entry

## Test plan

- [ ] After merging, verify `demo-app` appears under **Security → Dependabot** on GitHub
- [ ] Trigger a manual check via **Check for updates** to confirm dependency scanning works

🤖 Generated with [Claude Code](https://claude.com/claude-code)