### PR TITLE
chore: switch indentation to spaces, add AGENTS.md, minor stability/Compose fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ trim_trailing_whitespace = true
 
 [*.{kt,kts}]
 charset = utf-8
-indent_style = tab
+indent_style = space
 indent_size = 4
 # ktlint configuration
 ktlint_code_style = android_studio

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents working in this repository.
+
+## Project overview
+
+Reveal is a Kotlin Multiplatform library (Compose Multiplatform) implementing a "reveal" / coach
+mark / onboarding effect, targeting Android, iOS, Desktop and Web.
+
+Modules:
+
+| Module                  | Purpose                                                                                            |
+|-------------------------|----------------------------------------------------------------------------------------------------|
+| `reveal-common`         | Shared common code used by other modules (commonMain only)                                         |
+| `reveal-core`           | Core library: `RevealCanvas`, `Reveal` composable, public API                                      |
+| `reveal-shapes`         | Additional shapes for explanatory overlay items                                                    |
+| `reveal-compat-android` | Compatibility utilities for mixed View/Compose Android setups                                      |
+| `android-tests`         | Android instrumentation/screenshot tests (Roborazzi) for the library                               |
+| `demo-app`              | Separate Gradle build (own `settings.gradle.kts`) demonstrating usage across Android/iOS/Desktop   |
+| `convention-plugins`    | Gradle convention plugins (`convention.multiplatform`, `convention.publication`) shared by modules |
+
+`reveal-core`, `reveal-shapes` and `reveal-common` are Kotlin Multiplatform modules using
+`commonMain`/`commonTest` source sets (plus Android-specific source sets like `androidUnitTest`
+where relevant). `reveal-compat-android` and `android-tests` are Android-only.
+
+`demo-app` is its own root project with a separate `settings.gradle.kts` and Gradle wrapper —
+treat it as an independent build, not a subproject of the root build.
+
+## Build & test commands
+
+Run from the repository root unless noted otherwise.
+
+```bash
+./gradlew check                               # Run all checks (lint, tests, API validation, kotlinter) for the root build
+./gradlew :reveal-core:test                   # Run common/unit tests for a single module
+./gradlew :android-tests:verifyRoborazziDebug # Verify screenshot tests
+./gradlew :android-tests:recordRoborazziDebug # Re-record screenshot baselines after an intentional UI change
+./gradlew connectedAndroidTest                # Run instrumented tests on a connected device/emulator
+./gradlew apiDump                             # Regenerate public API dump files (api/ dirs) after a public API change
+./gradlew apiCheck                            # Verify the public API surface matches the committed dump (part of `check`)
+./gradlew formatKotlin                        # Auto-format Kotlin code with kotlinter/ktlint
+./gradlew lintKotlin                          # Check Kotlin formatting without modifying files
+```
+
+The `demo-app` directory is a separate Gradle build; run its own `./gradlew` from inside
+`demo-app/` (e.g. `cd demo-app && ./gradlew build`).
+
+CI (`.github/workflows/verify-pr.yml`) runs `./gradlew check`,
+`:android-tests:verifyRoborazziDebug`, and `connectedAndroidTest` on API levels 23 and 29 — mirror
+these locally before considering a change done.
+
+## Code style
+
+- Indentation is **spaces**, size 4 (see `.editorconfig`). Do not convert to tabs.
+- Kotlin formatting/linting is enforced by `kotlinter` (ktlint, `android_studio` code style) on
+  every `check` build. Run `./gradlew formatKotlin` to auto-fix style issues before finishing a
+  change.
+- Trailing commas are allowed both in declarations and at call sites.
+- `@Composable`-annotated functions are exempt from the function-naming lint rule (so
+  PascalCase composable function names are expected and correct).
+
+## Public API surface
+
+`reveal-core`, `reveal-shapes` and `reveal-compat-android` use the Kotlin binary-compatibility
+validator. Each module has an `api/` directory with dumped public API signatures (including
+per-target `.klib` dumps). Any change to public API (new/changed/removed public
+classes/functions/properties) requires running `./gradlew apiDump` and committing the updated
+files in `api/`, otherwise `./gradlew check` (via `apiCheck`) will fail.
+
+## Versioning & publishing
+
+- The library version is derived from the `RELEASE_TAG_NAME` environment variable (set in CI on
+  release); locally it builds as `SNAPSHOT`. Do not hardcode version numbers in module build
+  files.
+- Publishing to Maven Central (Sonatype) is handled by the `convention.publication` plugin and the
+  `deploy-release.yml` workflow — this is not something to trigger from local changes.
+
+## Working in this repo
+
+- Minimum Android SDK is 23 (`androidMinSdk` in the root `build.gradle.kts`); avoid introducing
+  APIs that require a higher minSdk without updating that constant deliberately.
+- Prefer adding code to the most specific module that needs it: shared/common logic with no
+  platform dependency belongs in `reveal-common`; public reveal-effect API belongs in
+  `reveal-core`; optional shapes belong in `reveal-shapes`.
+- When changing visual/overlay behavior, check whether `android-tests` screenshot baselines need
+  re-recording (`recordRoborazziDebug`) and review the resulting screenshots before committing
+  them.
+- Any non-trivial change should be validated with all three test layers before being considered
+  done: unit tests (`./gradlew test` / module-specific `test` tasks), instrumentation tests
+  (`./gradlew connectedAndroidTest`), and screenshot tests
+  (`./gradlew :android-tests:verifyRoborazziDebug`). CI runs all three, so a change that only
+  passes one of them is not complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/android-tests/build.gradle.kts
+++ b/android-tests/build.gradle.kts
@@ -1,98 +1,98 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-	alias(libs.plugins.android.application)
-	alias(libs.plugins.compose.compiler)
-	alias(libs.plugins.roborazzi)
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.roborazzi)
 }
 
 val androidTargetSdk: Int by rootProject.extra
 val androidCompileSdk: Int by rootProject.extra
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 android {
-	namespace = "com.svenjacobs.reveal.android.tests"
-	compileSdk { version = release(androidCompileSdk) }
+    namespace = "com.svenjacobs.reveal.android.tests"
+    compileSdk { version = release(androidCompileSdk) }
 
-	defaultConfig {
-		applicationId = "com.svenjacobs.reveal.android.tests"
-		minSdk { version = release(23) }
-		targetSdk { version = release(androidTargetSdk) }
-		versionCode = 1
-		versionName = "1.0"
+    defaultConfig {
+        applicationId = "com.svenjacobs.reveal.android.tests"
+        minSdk { version = release(23) }
+        targetSdk { version = release(androidTargetSdk) }
+        versionCode = 1
+        versionName = "1.0"
 
-		testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-	}
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
 
-	buildTypes {
-		release {
-			isMinifyEnabled = false
-			proguardFiles(
-				getDefaultProguardFile("proguard-android-optimize.txt"),
-				"proguard-rules.pro",
-			)
-		}
-	}
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
 
-	compileOptions {
-		sourceCompatibility = JavaVersion.VERSION_11
-		targetCompatibility = JavaVersion.VERSION_11
-	}
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
 
-	buildFeatures {
-		compose = true
-	}
+    buildFeatures {
+        compose = true
+    }
 
-	testOptions {
-		unitTests {
-			isIncludeAndroidResources = true
-		}
-	}
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 kotlin {
-	compilerOptions {
-		jvmTarget = JvmTarget.JVM_11
-	}
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_11
+    }
 }
 
 dependencies {
-	implementation(project(":reveal-core"))
-	implementation(project(":reveal-shapes"))
+    implementation(project(":reveal-core"))
+    implementation(project(":reveal-shapes"))
 
-	val composeBom = platform(libs.androidx.compose.bom)
-	implementation(composeBom)
-	implementation(libs.androidx.compose.foundation)
-	implementation(libs.androidx.compose.runtime)
-	implementation(libs.androidx.compose.animation)
-	implementation(libs.androidx.compose.ui)
-	implementation(libs.androidx.compose.material3)
-	implementation(libs.androidx.compose.material.icons.extended)
-	implementation(libs.androidx.activity.compose)
+    val composeBom = platform(libs.androidx.compose.bom)
+    implementation(composeBom)
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.runtime)
+    implementation(libs.androidx.compose.animation)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.activity.compose)
 
-	debugImplementation(libs.androidx.compose.ui.test.manifest)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 
-	testImplementation(libs.junit)
-	testImplementation(composeBom)
-	testImplementation(libs.androidx.compose.ui.test.junit4)
-	testImplementation(libs.androidx.compose.material3)
-	testImplementation(libs.androidx.test.ext.junit)
-	testImplementation(libs.robolectric)
-	testImplementation(libs.roborazzi)
-	testImplementation(libs.roborazzi.compose)
-	testImplementation(libs.roborazzi.junit.rule)
-	testImplementation(libs.androidx.compose.ui.test.manifest)
+    testImplementation(libs.junit)
+    testImplementation(composeBom)
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.androidx.compose.material3)
+    testImplementation(libs.androidx.test.ext.junit)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.roborazzi)
+    testImplementation(libs.roborazzi.compose)
+    testImplementation(libs.roborazzi.junit.rule)
+    testImplementation(libs.androidx.compose.ui.test.manifest)
 
-	androidTestImplementation(composeBom)
-	androidTestImplementation(libs.androidx.test.ext.junit)
-	androidTestImplementation(libs.androidx.test.espresso.core)
-	androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-	androidTestImplementation(libs.androidx.compose.material3)
+    androidTestImplementation(composeBom)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.androidx.compose.material3)
 
-	lintChecks(libs.slack.compose.lint.checks)
+    lintChecks(libs.slack.compose.lint.checks)
 }

--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/BaseRevealTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/BaseRevealTest.kt
@@ -17,57 +17,57 @@ import org.junit.Rule
 
 abstract class BaseRevealTest {
 
-	internal enum class Keys { Key1, Key2, Key3 }
+    internal enum class Keys { Key1, Key2, Key3 }
 
-	@get:Rule
-	val composeTestRule: ComposeContentTestRule = createComposeRule()
+    @get:Rule
+    val composeTestRule: ComposeContentTestRule = createComposeRule()
 
-	internal fun test(
-		onRevealableClick: OnClickListener = {},
-		onOverlayClick: OnClickListener = {},
-		body: (
-			testRule: ComposeContentTestRule,
-			revealState: RevealState,
-			scope: CoroutineScope,
-		) -> Unit,
-	) {
-		lateinit var revealState: RevealState
-		lateinit var scope: CoroutineScope
+    internal fun test(
+        onRevealableClick: OnClickListener = {},
+        onOverlayClick: OnClickListener = {},
+        body: (
+            testRule: ComposeContentTestRule,
+            revealState: RevealState,
+            scope: CoroutineScope,
+        ) -> Unit,
+    ) {
+        lateinit var revealState: RevealState
+        lateinit var scope: CoroutineScope
 
-		composeTestRule.setContent {
-			scope = rememberCoroutineScope()
-			revealState = rememberRevealState()
+        composeTestRule.setContent {
+            scope = rememberCoroutineScope()
+            revealState = rememberRevealState()
 
-			val revealCanvasState = rememberRevealCanvasState()
+            val revealCanvasState = rememberRevealCanvasState()
 
-			RevealCanvas(revealCanvasState = revealCanvasState) {
-				Reveal(
-					// this must take full screen for correct clicks handling by test runner
-					modifier = Modifier.fillMaxSize(),
-					onRevealableClick = onRevealableClick,
-					onOverlayClick = onOverlayClick,
-					revealCanvasState = revealCanvasState,
-					revealState = revealState,
-					overlayContent = { key ->
-						when (key) {
-							Keys.Key1 -> Text("Overlay1")
-							Keys.Key2 -> Text("Overlay2")
-						}
-					},
-				) {
-					Text(
-						modifier = Modifier.revealable(key = Keys.Key1),
-						text = "Element1",
-					)
+            RevealCanvas(revealCanvasState = revealCanvasState) {
+                Reveal(
+                    // this must take full screen for correct clicks handling by test runner
+                    modifier = Modifier.fillMaxSize(),
+                    onRevealableClick = onRevealableClick,
+                    onOverlayClick = onOverlayClick,
+                    revealCanvasState = revealCanvasState,
+                    revealState = revealState,
+                    overlayContent = { key ->
+                        when (key) {
+                            Keys.Key1 -> Text("Overlay1")
+                            Keys.Key2 -> Text("Overlay2")
+                        }
+                    },
+                ) {
+                    Text(
+                        modifier = Modifier.revealable(key = Keys.Key1),
+                        text = "Element1",
+                    )
 
-					Text(
-						modifier = Modifier.revealable(key = Keys.Key2),
-						text = "Element2",
-					)
-				}
-			}
-		}
+                    Text(
+                        modifier = Modifier.revealable(key = Keys.Key2),
+                        text = "Element2",
+                    )
+                }
+            }
+        }
 
-		body(composeTestRule, revealState, scope)
-	}
+        body(composeTestRule, revealState, scope)
+    }
 }

--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealOverlayBoundsTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealOverlayBoundsTest.kt
@@ -37,135 +37,135 @@ import org.junit.Test
  */
 class RevealOverlayBoundsTest {
 
-	private enum class Keys { Target }
+    private enum class Keys { Target }
 
-	@get:Rule
-	val composeTestRule: ComposeContentTestRule = createComposeRule()
+    @get:Rule
+    val composeTestRule: ComposeContentTestRule = createComposeRule()
 
-	@Test
-	fun topArrangementStaysWithinScreen() {
-		// Reveal area near the left edge, plenty of space above: a wide overlay centered above the
-		// reveal area would overflow the left boundary without dynamic adjustment.
-		assertOverlayWithinScreen(revealableAlignment = Alignment.BottomStart) {
-			OverlayBox(
-				modifier = Modifier.align(
-					verticalArrangement = RevealOverlayArrangement.Top,
-				),
-			)
-		}
-	}
+    @Test
+    fun topArrangementStaysWithinScreen() {
+        // Reveal area near the left edge, plenty of space above: a wide overlay centered above the
+        // reveal area would overflow the left boundary without dynamic adjustment.
+        assertOverlayWithinScreen(revealableAlignment = Alignment.BottomStart) {
+            OverlayBox(
+                modifier = Modifier.align(
+                    verticalArrangement = RevealOverlayArrangement.Top,
+                ),
+            )
+        }
+    }
 
-	@Test
-	fun bottomArrangementStaysWithinScreen() {
-		assertOverlayWithinScreen(revealableAlignment = Alignment.TopStart) {
-			OverlayBox(
-				modifier = Modifier.align(
-					verticalArrangement = RevealOverlayArrangement.Bottom,
-				),
-			)
-		}
-	}
+    @Test
+    fun bottomArrangementStaysWithinScreen() {
+        assertOverlayWithinScreen(revealableAlignment = Alignment.TopStart) {
+            OverlayBox(
+                modifier = Modifier.align(
+                    verticalArrangement = RevealOverlayArrangement.Bottom,
+                ),
+            )
+        }
+    }
 
-	@Test
-	fun startArrangementStaysWithinScreen() {
-		// Reveal area near the top edge, plenty of space to the start: a tall overlay centered
-		// vertically would overflow the top boundary without dynamic adjustment.
-		assertOverlayWithinScreen(revealableAlignment = Alignment.TopEnd) {
-			OverlayBox(
-				modifier = Modifier.align(
-					horizontalArrangement = RevealOverlayArrangement.Start,
-				),
-			)
-		}
-	}
+    @Test
+    fun startArrangementStaysWithinScreen() {
+        // Reveal area near the top edge, plenty of space to the start: a tall overlay centered
+        // vertically would overflow the top boundary without dynamic adjustment.
+        assertOverlayWithinScreen(revealableAlignment = Alignment.TopEnd) {
+            OverlayBox(
+                modifier = Modifier.align(
+                    horizontalArrangement = RevealOverlayArrangement.Start,
+                ),
+            )
+        }
+    }
 
-	@Test
-	fun endArrangementStaysWithinScreen() {
-		assertOverlayWithinScreen(revealableAlignment = Alignment.TopStart) {
-			OverlayBox(
-				modifier = Modifier.align(
-					horizontalArrangement = RevealOverlayArrangement.End,
-				),
-			)
-		}
-	}
+    @Test
+    fun endArrangementStaysWithinScreen() {
+        assertOverlayWithinScreen(revealableAlignment = Alignment.TopStart) {
+            OverlayBox(
+                modifier = Modifier.align(
+                    horizontalArrangement = RevealOverlayArrangement.End,
+                ),
+            )
+        }
+    }
 
-	@Composable
-	private fun OverlayBox(modifier: Modifier = Modifier) {
-		Box(
-			modifier = modifier
-				.size(width = 300.dp, height = 300.dp)
-				.testTag(OVERLAY_TAG),
-		)
-	}
+    @Composable
+    private fun OverlayBox(modifier: Modifier = Modifier) {
+        Box(
+            modifier = modifier
+                .size(width = 300.dp, height = 300.dp)
+                .testTag(OVERLAY_TAG),
+        )
+    }
 
-	private fun assertOverlayWithinScreen(
-		revealableAlignment: Alignment,
-		overlay: @Composable RevealOverlayScope.() -> Unit,
-	) {
-		lateinit var revealState: RevealState
-		lateinit var scope: CoroutineScope
+    private fun assertOverlayWithinScreen(
+        revealableAlignment: Alignment,
+        overlay: @Composable RevealOverlayScope.() -> Unit,
+    ) {
+        lateinit var revealState: RevealState
+        lateinit var scope: CoroutineScope
 
-		composeTestRule.setContent {
-			scope = rememberCoroutineScope()
-			revealState = rememberRevealState()
-			val revealCanvasState = rememberRevealCanvasState()
+        composeTestRule.setContent {
+            scope = rememberCoroutineScope()
+            revealState = rememberRevealState()
+            val revealCanvasState = rememberRevealCanvasState()
 
-			RevealCanvas(
-				revealCanvasState = revealCanvasState,
-				modifier = Modifier.fillMaxSize(),
-			) {
-				Reveal(
-					modifier = Modifier.fillMaxSize(),
-					revealCanvasState = revealCanvasState,
-					revealState = revealState,
-					overlayContent = { overlay() },
-				) {
-					Box(modifier = Modifier.fillMaxSize()) {
-						Box(
-							modifier = Modifier
-								.align(revealableAlignment)
-								.padding(16.dp)
-								.size(24.dp)
-								.revealable(
-									key = Keys.Target,
-									padding = PaddingValues(0.dp),
-								),
-						)
-					}
-				}
-			}
-		}
+            RevealCanvas(
+                revealCanvasState = revealCanvasState,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                Reveal(
+                    modifier = Modifier.fillMaxSize(),
+                    revealCanvasState = revealCanvasState,
+                    revealState = revealState,
+                    overlayContent = { overlay() },
+                ) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        Box(
+                            modifier = Modifier
+                                .align(revealableAlignment)
+                                .padding(16.dp)
+                                .size(24.dp)
+                                .revealable(
+                                    key = Keys.Target,
+                                    padding = PaddingValues(0.dp),
+                                ),
+                        )
+                    }
+                }
+            }
+        }
 
-		scope.launch { revealState.reveal(Keys.Target) }
-		composeTestRule.waitForIdle()
-		composeTestRule.waitUntil(timeoutMillis = 5_000) {
-			composeTestRule.onAllNodesWithTag(OVERLAY_TAG).fetchSemanticsNodes().isNotEmpty()
-		}
+        scope.launch { revealState.reveal(Keys.Target) }
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag(OVERLAY_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
 
-		val root = composeTestRule.onRoot().getUnclippedBoundsInRoot()
-		val overlayBounds = composeTestRule.onNodeWithTag(OVERLAY_TAG).getUnclippedBoundsInRoot()
+        val root = composeTestRule.onRoot().getUnclippedBoundsInRoot()
+        val overlayBounds = composeTestRule.onNodeWithTag(OVERLAY_TAG).getUnclippedBoundsInRoot()
 
-		assertTrue(
-			"Overlay overflows left edge: left=${overlayBounds.left}, root left=${root.left}",
-			overlayBounds.left.value >= root.left.value - TOLERANCE,
-		)
-		assertTrue(
-			"Overlay overflows top edge: top=${overlayBounds.top}, root top=${root.top}",
-			overlayBounds.top.value >= root.top.value - TOLERANCE,
-		)
-		assertTrue(
-			"Overlay overflows right edge: right=${overlayBounds.right}, root right=${root.right}",
-			overlayBounds.right.value <= root.right.value + TOLERANCE,
-		)
-		assertTrue(
-			"Overlay overflows bottom edge: bottom=${overlayBounds.bottom}, root bottom=${root.bottom}",
-			overlayBounds.bottom.value <= root.bottom.value + TOLERANCE,
-		)
-	}
+        assertTrue(
+            "Overlay overflows left edge: left=${overlayBounds.left}, root left=${root.left}",
+            overlayBounds.left.value >= root.left.value - TOLERANCE,
+        )
+        assertTrue(
+            "Overlay overflows top edge: top=${overlayBounds.top}, root top=${root.top}",
+            overlayBounds.top.value >= root.top.value - TOLERANCE,
+        )
+        assertTrue(
+            "Overlay overflows right edge: right=${overlayBounds.right}, root right=${root.right}",
+            overlayBounds.right.value <= root.right.value + TOLERANCE,
+        )
+        assertTrue(
+            "Overlay overflows bottom edge: bottom=${overlayBounds.bottom}, root bottom=${root.bottom}",
+            overlayBounds.bottom.value <= root.bottom.value + TOLERANCE,
+        )
+    }
 
-	private companion object {
-		const val OVERLAY_TAG = "overlayContent"
-		const val TOLERANCE = 0.5f
-	}
+    private companion object {
+        const val OVERLAY_TAG = "overlayContent"
+        const val TOLERANCE = 0.5f
+    }
 }

--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealOverlayTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealOverlayTest.kt
@@ -9,42 +9,42 @@ import org.junit.Test
 
 class RevealOverlayTest : BaseRevealTest() {
 
-	@Test
-	fun revealShowsOverlay() {
-		test { testRule, revealState, scope ->
-			scope.launch { revealState.reveal(Keys.Key1) }
+    @Test
+    fun revealShowsOverlay() {
+        test { testRule, revealState, scope ->
+            scope.launch { revealState.reveal(Keys.Key1) }
 
-			assertTrue(revealState.isVisible)
-			assertEquals(null, revealState.previousRevealableKey)
-			assertEquals(Keys.Key1, revealState.currentRevealableKey)
+            assertTrue(revealState.isVisible)
+            assertEquals(null, revealState.previousRevealableKey)
+            assertEquals(Keys.Key1, revealState.currentRevealableKey)
 
-			testRule.onNodeWithText("Overlay1").assertExists()
-			testRule.onNodeWithText("Overlay2").assertDoesNotExist()
+            testRule.onNodeWithText("Overlay1").assertExists()
+            testRule.onNodeWithText("Overlay2").assertDoesNotExist()
 
-			scope.launch { revealState.reveal(Keys.Key2) }
+            scope.launch { revealState.reveal(Keys.Key2) }
 
-			assertTrue(revealState.isVisible)
-			assertEquals(Keys.Key1, revealState.previousRevealableKey)
-			assertEquals(Keys.Key2, revealState.currentRevealableKey)
+            assertTrue(revealState.isVisible)
+            assertEquals(Keys.Key1, revealState.previousRevealableKey)
+            assertEquals(Keys.Key2, revealState.currentRevealableKey)
 
-			testRule.onNodeWithText("Overlay1").assertDoesNotExist()
-			testRule.onNodeWithText("Overlay2").assertExists()
-		}
-	}
+            testRule.onNodeWithText("Overlay1").assertDoesNotExist()
+            testRule.onNodeWithText("Overlay2").assertExists()
+        }
+    }
 
-	@Test
-	fun hideHidesOverlay() {
-		test { testRule, revealState, scope ->
-			scope.launch { revealState.reveal(Keys.Key1) }
+    @Test
+    fun hideHidesOverlay() {
+        test { testRule, revealState, scope ->
+            scope.launch { revealState.reveal(Keys.Key1) }
 
-			assertTrue(revealState.isVisible)
-			assertEquals(Keys.Key1, revealState.currentRevealableKey)
+            assertTrue(revealState.isVisible)
+            assertEquals(Keys.Key1, revealState.currentRevealableKey)
 
-			scope.launch { revealState.hide() }
+            scope.launch { revealState.hide() }
 
-			assertFalse(revealState.isVisible)
+            assertFalse(revealState.isVisible)
 
-			testRule.onNodeWithText("Overlay1").assertDoesNotExist()
-		}
-	}
+            testRule.onNodeWithText("Overlay1").assertDoesNotExist()
+        }
+    }
 }

--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealStateTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealStateTest.kt
@@ -6,12 +6,12 @@ import org.junit.Test
 
 class RevealStateTest : BaseRevealTest() {
 
-	@Test
-	fun stateContainsKeys() {
-		test { _, revealState, _ ->
-			assertTrue(revealState.revealableKeys.contains(Keys.Key1))
-			assertTrue(revealState.revealableKeys.contains(Keys.Key2))
-			assertFalse(revealState.revealableKeys.contains(Keys.Key3))
-		}
-	}
+    @Test
+    fun stateContainsKeys() {
+        test { _, revealState, _ ->
+            assertTrue(revealState.revealableKeys.contains(Keys.Key1))
+            assertTrue(revealState.revealableKeys.contains(Keys.Key2))
+            assertFalse(revealState.revealableKeys.contains(Keys.Key3))
+        }
+    }
 }

--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealTest.kt
@@ -10,37 +10,37 @@ import org.junit.Test
 
 class RevealTest : BaseRevealTest() {
 
-	@Test
-	fun clickCallsOnRevealableClick() {
-		var onRevealableClickKey: Key? = null
+    @Test
+    fun clickCallsOnRevealableClick() {
+        var onRevealableClickKey: Key? = null
 
-		test(
-			onRevealableClick = { key -> onRevealableClickKey = key },
-		) { testRule, revealState, scope ->
-			scope.launch { revealState.reveal(Keys.Key1) }
+        test(
+            onRevealableClick = { key -> onRevealableClickKey = key },
+        ) { testRule, revealState, scope ->
+            scope.launch { revealState.reveal(Keys.Key1) }
 
-			testRule.onNodeWithText("Overlay1")
-				.assertExists()
-				.performClick()
+            testRule.onNodeWithText("Overlay1")
+                .assertExists()
+                .performClick()
 
-			assertEquals(Keys.Key1, onRevealableClickKey)
-		}
-	}
+            assertEquals(Keys.Key1, onRevealableClickKey)
+        }
+    }
 
-	@Test
-	fun clickCallsOnOverlayClick() {
-		var onOverlayClickKey: Key? = null
+    @Test
+    fun clickCallsOnOverlayClick() {
+        var onOverlayClickKey: Key? = null
 
-		test(
-			onOverlayClick = { key -> onOverlayClickKey = key },
-		) { testRule, revealState, scope ->
-			scope.launch { revealState.reveal(Keys.Key1) }
+        test(
+            onOverlayClick = { key -> onOverlayClickKey = key },
+        ) { testRule, revealState, scope ->
+            scope.launch { revealState.reveal(Keys.Key1) }
 
-			testRule.onNodeWithTag("overlay")
-				.assertExists()
-				.performClick()
+            testRule.onNodeWithTag("overlay")
+                .assertExists()
+                .performClick()
 
-			assertEquals(Keys.Key1, onOverlayClickKey)
-		}
-	}
+            assertEquals(Keys.Key1, onOverlayClickKey)
+        }
+    }
 }

--- a/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/App.kt
+++ b/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/App.kt
@@ -6,9 +6,9 @@ import com.svenjacobs.reveal.common.internal.log.Logger
 
 class App : Application() {
 
-	override fun onCreate() {
-		super.onCreate()
+    override fun onCreate() {
+        super.onCreate()
 
-		Logger.adapter = Logger.Adapter { message, tag -> Log.d(tag, message) }
-	}
+        Logger.adapter = Logger.Adapter { message, tag -> Log.d(tag, message) }
+    }
 }

--- a/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/MainActivity.kt
+++ b/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/MainActivity.kt
@@ -8,13 +8,13 @@ import com.svenjacobs.reveal.android.tests.presentation.App
 
 class MainActivity : ComponentActivity() {
 
-	override fun onCreate(savedInstanceState: Bundle?) {
-		super.onCreate(savedInstanceState)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
 
-		WindowCompat.setDecorFitsSystemWindows(window, false)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
-		setContent {
-			App()
-		}
-	}
+        setContent {
+            App()
+        }
+    }
 }

--- a/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/presentation/App.kt
+++ b/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/presentation/App.kt
@@ -8,14 +8,14 @@ import com.svenjacobs.reveal.rememberRevealCanvasState
 
 @Composable
 fun App(modifier: Modifier = Modifier) {
-	AppTheme {
-		val revealCanvasState = rememberRevealCanvasState()
+    AppTheme {
+        val revealCanvasState = rememberRevealCanvasState()
 
-		RevealCanvas(
-			revealCanvasState = revealCanvasState,
-			modifier = modifier,
-		) {
-			MainScreen(revealCanvasState = revealCanvasState)
-		}
-	}
+        RevealCanvas(
+            revealCanvasState = revealCanvasState,
+            modifier = modifier,
+        ) {
+            MainScreen(revealCanvasState = revealCanvasState)
+        }
+    }
 }

--- a/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/presentation/MainScreen.kt
+++ b/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/presentation/MainScreen.kt
@@ -40,111 +40,111 @@ private enum class Keys { Fab, Explanation }
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun MainScreen(revealCanvasState: RevealCanvasState, modifier: Modifier = Modifier) {
-	val scope = rememberCoroutineScope()
-	val revealState = rememberRevealState()
+    val scope = rememberCoroutineScope()
+    val revealState = rememberRevealState()
 
-	LaunchedEffect(Unit) {
-		if (revealState.isVisible) return@LaunchedEffect
-		delay(2.seconds)
-		revealState.reveal(Keys.Fab)
-	}
+    LaunchedEffect(Unit) {
+        if (revealState.isVisible) return@LaunchedEffect
+        delay(2.seconds)
+        revealState.reveal(Keys.Fab)
+    }
 
-	Reveal(
-		onOverlayClick = { scope.launch { revealState.hide() } },
-		modifier = modifier,
-		revealCanvasState = revealCanvasState,
-		revealState = revealState,
-		overlayContent = { key -> RevealOverlayContent(key) },
-	) {
-		Scaffold(
-			modifier = Modifier.fillMaxSize(),
-			topBar = {
-				CenterAlignedTopAppBar(
-					title = { Text("Reveal Demo") },
-				)
-			},
-			floatingActionButton = {
-				FloatingActionButton(
-					modifier = Modifier.revealable(
-						key = Keys.Fab,
-						shape = RevealShape.RoundRect(16.dp),
-						borderStroke = BorderStroke(2.dp, Color.DarkGray),
-						onClick = OnClick.Listener {
-							scope.launch { revealState.reveal(Keys.Explanation) }
-						},
-					),
-					onClick = {
-						scope.launch { revealState.reveal(Keys.Explanation) }
-					},
-				) {
-					Icon(
-						Icons.Filled.Add,
-						contentDescription = null,
-					)
-				}
-			},
-		) { contentPadding ->
-			Column(
-				modifier = Modifier
-					.fillMaxSize()
-					.padding(contentPadding)
-					.padding(horizontal = 16.dp),
-				horizontalAlignment = Alignment.CenterHorizontally,
-			) {
-				Text(
-					modifier = Modifier
-						.padding(top = 16.dp)
-						.revealable(
-							key = Keys.Explanation,
-							borderStroke = BorderStroke(2.dp, Color.DarkGray),
-							onClick = OnClick.Listener {
-								scope.launch { revealState.hide() }
-							},
-						),
-					text = "Reveal is a lightweight, simple reveal effect (also known as " +
-						"coach mark or onboarding) library for Compose Multiplatform.",
-					style = MaterialTheme.typography.bodyLarge,
-					textAlign = TextAlign.Justify,
-				)
-			}
-		}
-	}
+    Reveal(
+        onOverlayClick = { scope.launch { revealState.hide() } },
+        modifier = modifier,
+        revealCanvasState = revealCanvasState,
+        revealState = revealState,
+        overlayContent = { key -> RevealOverlayContent(key) },
+    ) {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = { Text("Reveal Demo") },
+                )
+            },
+            floatingActionButton = {
+                FloatingActionButton(
+                    modifier = Modifier.revealable(
+                        key = Keys.Fab,
+                        shape = RevealShape.RoundRect(16.dp),
+                        borderStroke = BorderStroke(2.dp, Color.DarkGray),
+                        onClick = OnClick.Listener {
+                            scope.launch { revealState.reveal(Keys.Explanation) }
+                        },
+                    ),
+                    onClick = {
+                        scope.launch { revealState.reveal(Keys.Explanation) }
+                    },
+                ) {
+                    Icon(
+                        Icons.Filled.Add,
+                        contentDescription = null,
+                    )
+                }
+            },
+        ) { contentPadding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(contentPadding)
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .revealable(
+                            key = Keys.Explanation,
+                            borderStroke = BorderStroke(2.dp, Color.DarkGray),
+                            onClick = OnClick.Listener {
+                                scope.launch { revealState.hide() }
+                            },
+                        ),
+                    text = "Reveal is a lightweight, simple reveal effect (also known as " +
+                        "coach mark or onboarding) library for Compose Multiplatform.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Justify,
+                )
+            }
+        }
+    }
 }
 
 @Composable
 private fun RevealOverlayScope.RevealOverlayContent(key: Key) {
-	when (key) {
-		Keys.Fab -> OverlayText(
-			modifier = Modifier.align(
-				horizontalArrangement = RevealOverlayArrangement.Start,
-			),
-			text = "Click button to get started",
-			arrow = Arrow.end(anchorToReveal = true),
-		)
+    when (key) {
+        Keys.Fab -> OverlayText(
+            modifier = Modifier.align(
+                horizontalArrangement = RevealOverlayArrangement.Start,
+            ),
+            text = "Click button to get started",
+            arrow = Arrow.end(anchorToReveal = true),
+        )
 
-		Keys.Explanation -> OverlayText(
-			modifier = Modifier.align(
-				verticalArrangement = RevealOverlayArrangement.Bottom,
-			),
-			text = "Actually we already started. This was an example of the reveal effect.",
-			arrow = Arrow.top(anchorToReveal = true),
-		)
-	}
+        Keys.Explanation -> OverlayText(
+            modifier = Modifier.align(
+                verticalArrangement = RevealOverlayArrangement.Bottom,
+            ),
+            text = "Actually we already started. This was an example of the reveal effect.",
+            arrow = Arrow.top(anchorToReveal = true),
+        )
+    }
 }
 
 @Composable
 private fun OverlayText(text: String, arrow: Arrow, modifier: Modifier = Modifier) {
-	Balloon(
-		modifier = modifier.padding(8.dp),
-		arrow = arrow,
-		backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
-		elevation = 2.dp,
-	) {
-		Text(
-			modifier = Modifier.padding(8.dp),
-			text = text,
-			style = MaterialTheme.typography.labelLarge,
-			textAlign = TextAlign.Center,
-		)
-	}
+    Balloon(
+        modifier = modifier.padding(8.dp),
+        arrow = arrow,
+        backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+        elevation = 2.dp,
+    ) {
+        Text(
+            modifier = Modifier.padding(8.dp),
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            textAlign = TextAlign.Center,
+        )
+    }
 }

--- a/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/presentation/theme/Theme.kt
+++ b/android-tests/src/main/kotlin/com/svenjacobs/reveal/android/tests/presentation/theme/Theme.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 fun AppTheme(content: @Composable () -> Unit) {
-	MaterialTheme(
-		content = content,
-	)
+    MaterialTheme(
+        content = content,
+    )
 }

--- a/android-tests/src/test/kotlin/com/svenjacobs/reveal/android/tests/RevealOverlayScreenshotTest.kt
+++ b/android-tests/src/test/kotlin/com/svenjacobs/reveal/android/tests/RevealOverlayScreenshotTest.kt
@@ -50,140 +50,144 @@ import org.robolectric.annotation.GraphicsMode
 @Config(qualifiers = "w360dp-h720dp-mdpi")
 class RevealOverlayScreenshotTest(private val case: Case) {
 
-	@get:Rule
-	val composeRule = createComposeRule()
+    @get:Rule
+    val composeRule = createComposeRule()
 
-	@Test
-	fun overlay() {
-		lateinit var revealState: RevealState
-		lateinit var scope: CoroutineScope
+    @Test
+    fun overlay() {
+        lateinit var revealState: RevealState
+        lateinit var scope: CoroutineScope
 
-		composeRule.setContent {
-			revealState = rememberRevealState()
-			scope = rememberCoroutineScope()
-			RevealScreenshotContent(case, revealState)
-		}
+        composeRule.setContent {
+            revealState = rememberRevealState()
+            scope = rememberCoroutineScope()
+            RevealScreenshotContent(case, revealState)
+        }
 
-		// Lay out the content first so the revealable is registered, then reveal it.
-		composeRule.waitForIdle()
-		scope.launch { revealState.reveal(KEY) }
-		composeRule.waitForIdle()
+        // Lay out the content first so the revealable is registered, then reveal it.
+        composeRule.waitForIdle()
+        scope.launch { revealState.reveal(KEY) }
+        composeRule.waitForIdle()
 
-		composeRule.onRoot().captureRoboImage("screenshots/${case.id}.png")
-	}
+        composeRule.onRoot().captureRoboImage("screenshots/${case.id}.png")
+    }
 
-	enum class Arrangement { Top, Bottom, Start, End }
+    enum class Arrangement { Top, Bottom, Start, End }
 
-	enum class GridPosition(val alignment: Alignment) {
-		TopStart(Alignment.TopStart),
-		TopCenter(Alignment.TopCenter),
-		TopEnd(Alignment.TopEnd),
-		CenterStart(Alignment.CenterStart),
-		Center(Alignment.Center),
-		CenterEnd(Alignment.CenterEnd),
-		BottomStart(Alignment.BottomStart),
-		BottomCenter(Alignment.BottomCenter),
-		BottomEnd(Alignment.BottomEnd),
-	}
+    enum class GridPosition(val alignment: Alignment) {
+        TopStart(Alignment.TopStart),
+        TopCenter(Alignment.TopCenter),
+        TopEnd(Alignment.TopEnd),
+        CenterStart(Alignment.CenterStart),
+        Center(Alignment.Center),
+        CenterEnd(Alignment.CenterEnd),
+        BottomStart(Alignment.BottomStart),
+        BottomCenter(Alignment.BottomCenter),
+        BottomEnd(Alignment.BottomEnd),
+    }
 
-	data class Case(val position: GridPosition, val arrangement: Arrangement, val anchored: Boolean) {
-		val id: String =
-			"${arrangement.name.lowercase()}_${position.name}_${if (anchored) "anchored" else "centered"}"
+    data class Case(
+        val position: GridPosition,
+        val arrangement: Arrangement,
+        val anchored: Boolean,
+    ) {
+        val id: String =
+            "${arrangement.name.lowercase()}_${position.name}_${if (anchored) "anchored" else "centered"}"
 
-		override fun toString(): String = id
-	}
+        override fun toString(): String = id
+    }
 
-	companion object {
-		const val KEY: String = "target"
+    companion object {
+        const val KEY: String = "target"
 
-		@JvmStatic
-		@ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
-		fun cases(): List<Case> = buildList {
-			for (position in GridPosition.entries) {
-				for (arrangement in Arrangement.entries) {
-					for (anchored in listOf(true, false)) {
-						add(Case(position, arrangement, anchored))
-					}
-				}
-			}
-		}
-	}
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
+        fun cases(): List<Case> = buildList {
+            for (position in GridPosition.entries) {
+                for (arrangement in Arrangement.entries) {
+                    for (anchored in listOf(true, false)) {
+                        add(Case(position, arrangement, anchored))
+                    }
+                }
+            }
+        }
+    }
 }
 
 @Composable
 private fun RevealScreenshotContent(
-	case: RevealOverlayScreenshotTest.Case,
-	revealState: RevealState,
+    case: RevealOverlayScreenshotTest.Case,
+    revealState: RevealState,
 ) {
-	val revealCanvasState = rememberRevealCanvasState()
+    val revealCanvasState = rememberRevealCanvasState()
 
-	RevealCanvas(
-		revealCanvasState = revealCanvasState,
-		modifier = Modifier
-			.fillMaxSize()
-			.background(Color.White),
-	) {
-		Reveal(
-			modifier = Modifier.fillMaxSize(),
-			revealCanvasState = revealCanvasState,
-			revealState = revealState,
-			// Use instant animations so the overlay is fully visible for a deterministic capture.
-			overlayEffect = DimRevealOverlayEffect(
-				alphaAnimationSpec = snap(),
-				contentAlphaAnimationSpec = snap(),
-			),
-			overlayContent = { OverlayBalloon(case) },
-		) {
-			Box(modifier = Modifier.fillMaxSize()) {
-				Box(
-					modifier = Modifier
-						.align(case.position.alignment)
-						.padding(24.dp)
-						.size(48.dp)
-						.background(Color.Blue)
-						.revealable(key = RevealOverlayScreenshotTest.KEY),
-				)
-			}
-		}
-	}
+    RevealCanvas(
+        revealCanvasState = revealCanvasState,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White),
+    ) {
+        Reveal(
+            modifier = Modifier.fillMaxSize(),
+            revealCanvasState = revealCanvasState,
+            revealState = revealState,
+            // Use instant animations so the overlay is fully visible for a deterministic capture.
+            overlayEffect = DimRevealOverlayEffect(
+                alphaAnimationSpec = snap(),
+                contentAlphaAnimationSpec = snap(),
+            ),
+            overlayContent = { OverlayBalloon(case) },
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .align(case.position.alignment)
+                        .padding(24.dp)
+                        .size(48.dp)
+                        .background(Color.Blue)
+                        .revealable(key = RevealOverlayScreenshotTest.KEY),
+                )
+            }
+        }
+    }
 }
 
 @Composable
 private fun RevealOverlayScope.OverlayBalloon(case: RevealOverlayScreenshotTest.Case) {
-	val anchored = case.anchored
-	val modifier: Modifier
-	val arrow: Arrow
-	when (case.arrangement) {
-		RevealOverlayScreenshotTest.Arrangement.Top -> {
-			modifier = Modifier.align(verticalArrangement = RevealOverlayArrangement.Top)
-			arrow = Arrow.bottom(anchorToReveal = anchored)
-		}
+    val anchored = case.anchored
+    val modifier: Modifier
+    val arrow: Arrow
+    when (case.arrangement) {
+        RevealOverlayScreenshotTest.Arrangement.Top -> {
+            modifier = Modifier.align(verticalArrangement = RevealOverlayArrangement.Top)
+            arrow = Arrow.bottom(anchorToReveal = anchored)
+        }
 
-		RevealOverlayScreenshotTest.Arrangement.Bottom -> {
-			modifier = Modifier.align(verticalArrangement = RevealOverlayArrangement.Bottom)
-			arrow = Arrow.top(anchorToReveal = anchored)
-		}
+        RevealOverlayScreenshotTest.Arrangement.Bottom -> {
+            modifier = Modifier.align(verticalArrangement = RevealOverlayArrangement.Bottom)
+            arrow = Arrow.top(anchorToReveal = anchored)
+        }
 
-		RevealOverlayScreenshotTest.Arrangement.Start -> {
-			modifier = Modifier.align(horizontalArrangement = RevealOverlayArrangement.Start)
-			arrow = Arrow.end(anchorToReveal = anchored)
-		}
+        RevealOverlayScreenshotTest.Arrangement.Start -> {
+            modifier = Modifier.align(horizontalArrangement = RevealOverlayArrangement.Start)
+            arrow = Arrow.end(anchorToReveal = anchored)
+        }
 
-		RevealOverlayScreenshotTest.Arrangement.End -> {
-			modifier = Modifier.align(horizontalArrangement = RevealOverlayArrangement.End)
-			arrow = Arrow.start(anchorToReveal = anchored)
-		}
-	}
+        RevealOverlayScreenshotTest.Arrangement.End -> {
+            modifier = Modifier.align(horizontalArrangement = RevealOverlayArrangement.End)
+            arrow = Arrow.start(anchorToReveal = anchored)
+        }
+    }
 
-	Balloon(
-		modifier = modifier.padding(8.dp),
-		arrow = arrow,
-		backgroundColor = Color(0xFFD0D0FF),
-		cornerRadius = 8.dp,
-	) {
-		Text(
-			modifier = Modifier.padding(8.dp),
-			text = "Explanation text for the revealed item",
-		)
-	}
+    Balloon(
+        modifier = modifier.padding(8.dp),
+        arrow = arrow,
+        backgroundColor = Color(0xFFD0D0FF),
+        cornerRadius = 8.dp,
+    ) {
+        Text(
+            modifier = Modifier.padding(8.dp),
+            text = "Explanation text for the revealed item",
+        )
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,61 +1,61 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 plugins {
-	alias(libs.plugins.jetbrains.kotlin.multiplatform) apply false
-	alias(libs.plugins.jetbrains.compose) apply false
-	alias(libs.plugins.android.application) apply false
-	alias(libs.plugins.android.library) apply false
-	alias(libs.plugins.android.multiplatform.library) apply false
-	alias(libs.plugins.compose.compiler) apply false
-	alias(libs.plugins.nexus.publish)
-	alias(libs.plugins.ben.manes.versions)
-	alias(libs.plugins.kotlinter)
-	alias(libs.plugins.binary.compat.validator)
-	alias(libs.plugins.roborazzi) apply false
+    alias(libs.plugins.jetbrains.kotlin.multiplatform) apply false
+    alias(libs.plugins.jetbrains.compose) apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.android.multiplatform.library) apply false
+    alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.nexus.publish)
+    alias(libs.plugins.ben.manes.versions)
+    alias(libs.plugins.kotlinter)
+    alias(libs.plugins.binary.compat.validator)
+    alias(libs.plugins.roborazzi) apply false
 
-	// https://github.com/JetBrains/compose-multiplatform/issues/4773#issuecomment-2100795877
-	id("convention.multiplatform") apply false
-	id("convention.publication") apply false
+    // https://github.com/JetBrains/compose-multiplatform/issues/4773#issuecomment-2100795877
+    id("convention.multiplatform") apply false
+    id("convention.publication") apply false
 }
 
 group = "com.svenjacobs.reveal"
 version = (System.getenv("RELEASE_TAG_NAME") ?: "SNAPSHOT").replace("v", "")
 
 subprojects {
-	apply(plugin = "org.jmailen.kotlinter")
+    apply(plugin = "org.jmailen.kotlinter")
 }
 
 apiValidation {
-	ignoredProjects += listOf(
-		"android-tests",
-	)
+    ignoredProjects += listOf(
+        "android-tests",
+    )
 
-	@OptIn(kotlinx.validation.ExperimentalBCVApi::class)
-	klib {
-		enabled = true
-	}
+    @OptIn(kotlinx.validation.ExperimentalBCVApi::class)
+    klib {
+        enabled = true
+    }
 
 }
 
 nexusPublishing {
-	repositories {
-		sonatype {
-			nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-			snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-		}
-	}
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
+    }
 }
 
 tasks.withType<DependencyUpdatesTask> {
 
-	fun isNonStable(version: String) =
-		listOf("alpha", "beta", "rc", "eap", "-m", ".m", "-a", "dev").any {
-			version.lowercase().contains(it)
-		}
+    fun isNonStable(version: String) =
+        listOf("alpha", "beta", "rc", "eap", "-m", ".m", "-a", "dev").any {
+            version.lowercase().contains(it)
+        }
 
-	rejectVersionIf {
-		isNonStable(candidate.version) && !isNonStable(currentVersion)
-	}
+    rejectVersionIf {
+        isNonStable(candidate.version) && !isNonStable(currentVersion)
+    }
 }
 
 val androidMinSdk by extra { 23 }

--- a/convention-plugins/build.gradle.kts
+++ b/convention-plugins/build.gradle.kts
@@ -2,34 +2,34 @@ val catalogs = extensions.getByType<VersionCatalogsExtension>()
 val libs: VersionCatalog = catalogs.named("libs")
 
 plugins {
-	`kotlin-dsl`
+    `kotlin-dsl`
 }
 
 repositories {
-	google()
-	mavenCentral()
-	gradlePluginPortal()
+    google()
+    mavenCentral()
+    gradlePluginPortal()
 }
 
 dependencies {
-	implementation(
-		group = "org.jetbrains.kotlin",
-		name = "kotlin-gradle-plugin",
-		version = libs.findVersion("kotlin").get().requiredVersion,
-	)
-	implementation(
-		group = "org.jetbrains.compose",
-		name = "compose-gradle-plugin",
-		version = libs.findVersion("jetbrains-compose").get().requiredVersion,
-	)
-	implementation(
-		group = "org.jetbrains.kotlin.plugin.compose",
-		name = "org.jetbrains.kotlin.plugin.compose.gradle.plugin",
-		version = libs.findVersion("kotlin").get().requiredVersion,
-	)
-	implementation(
-		group = "com.android.tools.build",
-		name = "gradle",
-		version = libs.findVersion("android-gradle-plugin").get().requiredVersion,
-	)
+    implementation(
+        group = "org.jetbrains.kotlin",
+        name = "kotlin-gradle-plugin",
+        version = libs.findVersion("kotlin").get().requiredVersion,
+    )
+    implementation(
+        group = "org.jetbrains.compose",
+        name = "compose-gradle-plugin",
+        version = libs.findVersion("jetbrains-compose").get().requiredVersion,
+    )
+    implementation(
+        group = "org.jetbrains.kotlin.plugin.compose",
+        name = "org.jetbrains.kotlin.plugin.compose.gradle.plugin",
+        version = libs.findVersion("kotlin").get().requiredVersion,
+    )
+    implementation(
+        group = "com.android.tools.build",
+        name = "gradle",
+        version = libs.findVersion("android-gradle-plugin").get().requiredVersion,
+    )
 }

--- a/convention-plugins/settings.gradle.kts
+++ b/convention-plugins/settings.gradle.kts
@@ -1,7 +1,7 @@
 dependencyResolutionManagement {
-	versionCatalogs {
-		create("libs") {
-			from(files("../gradle/libs.versions.toml"))
-		}
-	}
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }

--- a/convention-plugins/src/main/kotlin/convention.multiplatform.gradle.kts
+++ b/convention-plugins/src/main/kotlin/convention.multiplatform.gradle.kts
@@ -3,50 +3,50 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-	kotlin("multiplatform")
-	id("com.android.kotlin.multiplatform.library")
-	id("org.jetbrains.compose")
-	id("org.jetbrains.kotlin.plugin.compose")
+    kotlin("multiplatform")
+    id("com.android.kotlin.multiplatform.library")
+    id("org.jetbrains.compose")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 kotlin {
-	applyDefaultHierarchyTemplate()
+    applyDefaultHierarchyTemplate()
 
-	jvm("desktop")
+    jvm("desktop")
 
-	android {
-		compilerOptions {
-			jvmTarget.set(JvmTarget.JVM_11)
-		}
-	}
+    android {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
 
-	listOf(
-		iosArm64(),
-		iosSimulatorArm64(),
-	).forEach {
-		afterEvaluate {
-			val baseName: String by extra
+    listOf(
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach {
+        afterEvaluate {
+            val baseName: String by extra
 
-			it.binaries.framework {
-				this.baseName = baseName
-			}
-		}
-	}
+            it.binaries.framework {
+                this.baseName = baseName
+            }
+        }
+    }
 
-	js(IR) {
-		browser()
-	}
+    js(IR) {
+        browser()
+    }
 
-	@OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
-	wasmJs {
-		browser()
-	}
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+    }
 
-	explicitApi()
+    explicitApi()
 }

--- a/convention-plugins/src/main/kotlin/convention.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/convention.publication.gradle.kts
@@ -1,75 +1,75 @@
 plugins {
-	`maven-publish`
-	signing
+    `maven-publish`
+    signing
 }
 
 val javadocJar by tasks.registering(Jar::class) {
-	archiveClassifier.set("javadoc")
+    archiveClassifier.set("javadoc")
 }
 
 publishing {
-	publications {
-		withType<MavenPublication> {
-			groupId = "com.svenjacobs.reveal"
-			version = (System.getenv("RELEASE_TAG_NAME") ?: "SNAPSHOT").replace("v", "")
+    publications {
+        withType<MavenPublication> {
+            groupId = "com.svenjacobs.reveal"
+            version = (System.getenv("RELEASE_TAG_NAME") ?: "SNAPSHOT").replace("v", "")
 
-			// Stub javadoc.jar artifact
-			artifact(javadocJar.get())
+            // Stub javadoc.jar artifact
+            artifact(javadocJar.get())
 
-			pom {
-				afterEvaluate {
-					val publicationName: String by extra
-					this@pom.name.set(publicationName)
-				}
-				description.set("Lightweight, simple reveal effect for Compose Multiplatform")
-				url.set("https://github.com/svenjacobs/reveal")
+            pom {
+                afterEvaluate {
+                    val publicationName: String by extra
+                    this@pom.name.set(publicationName)
+                }
+                description.set("Lightweight, simple reveal effect for Compose Multiplatform")
+                url.set("https://github.com/svenjacobs/reveal")
 
-				developers {
-					developer {
-						id.set("svenjacobs")
-						name.set("Sven Jacobs")
-						email.set("github@svenjacobs.com")
-						url.set("https://svenjacobs.com/")
-						timezone.set("GMT+1")
-					}
-				}
+                developers {
+                    developer {
+                        id.set("svenjacobs")
+                        name.set("Sven Jacobs")
+                        email.set("github@svenjacobs.com")
+                        url.set("https://svenjacobs.com/")
+                        timezone.set("GMT+1")
+                    }
+                }
 
-				licenses {
-					license {
-						name.set("MIT License")
-						url.set("https://opensource.org/licenses/MIT")
-					}
-				}
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://opensource.org/licenses/MIT")
+                    }
+                }
 
-				scm {
-					connection.set("scm:git:git://github.com/svenjacobs/reveal.git")
-					developerConnection.set("scm:git:git://github.com/svenjacobs/reveal.git")
-					url.set("https://github.com/svenjacobs/reveal")
-				}
-			}
-		}
-	}
+                scm {
+                    connection.set("scm:git:git://github.com/svenjacobs/reveal.git")
+                    developerConnection.set("scm:git:git://github.com/svenjacobs/reveal.git")
+                    url.set("https://github.com/svenjacobs/reveal")
+                }
+            }
+        }
+    }
 }
 
 signing {
-	// Store key and password in environment variables
-	// ORG_GRADLE_PROJECT_signingKey and ORG_GRADLE_PROJECT_signingPassword
-	//
-	// Set locally for testing:
-	//   export ORG_GRADLE_PROJECT_signingKey="$(gpg --export-secret-keys --armor mail@address)"
-	//   export ORG_GRADLE_PROJECT_signingPassword="password"
-	val signingKey: String? by project
-	val signingPassword: String? by project
+    // Store key and password in environment variables
+    // ORG_GRADLE_PROJECT_signingKey and ORG_GRADLE_PROJECT_signingPassword
+    //
+    // Set locally for testing:
+    //   export ORG_GRADLE_PROJECT_signingKey="$(gpg --export-secret-keys --armor mail@address)"
+    //   export ORG_GRADLE_PROJECT_signingPassword="password"
+    val signingKey: String? by project
+    val signingPassword: String? by project
 
-	if (!signingKey.isNullOrEmpty() && !signingPassword.isNullOrEmpty()) {
-		useInMemoryPgpKeys(signingKey, signingPassword)
-		sign(publishing.publications)
-	}
+    if (!signingKey.isNullOrEmpty() && !signingPassword.isNullOrEmpty()) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications)
+    }
 }
 
 // Fix for KMP signing issue
 // https://github.com/gradle/gradle/issues/26091#issuecomment-1722947958
 tasks.withType<AbstractPublishToMaven>().configureEach {
-	val signingTasks = tasks.withType<Sign>()
-	mustRunAfter(signingTasks)
+    val signingTasks = tasks.withType<Sign>()
+    mustRunAfter(signingTasks)
 }

--- a/demo-app/androidApp/build.gradle.kts
+++ b/demo-app/androidApp/build.gradle.kts
@@ -1,53 +1,53 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-	alias(libs.plugins.android.application)
-	alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
-	namespace = "com.svenjacobs.reveal.demo.android"
-	compileSdk { version = release(36) }
-	defaultConfig {
-		applicationId = "com.svenjacobs.reveal.demo.android"
-		minSdk { version = release(23) }
-		targetSdk { version = release(36) }
-		versionCode = 1
-		versionName = "1.0"
-	}
-	buildFeatures {
-		compose = true
-	}
-	packaging {
-		resources {
-			excludes += "/META-INF/{AL2.0,LGPL2.1}"
-		}
-	}
-	buildTypes {
-		getByName("release") {
-			isMinifyEnabled = false
-		}
-	}
-	compileOptions {
-		sourceCompatibility = JavaVersion.VERSION_17
-		targetCompatibility = JavaVersion.VERSION_17
-	}
+    namespace = "com.svenjacobs.reveal.demo.android"
+    compileSdk { version = release(37) }
+    defaultConfig {
+        applicationId = "com.svenjacobs.reveal.demo.android"
+        minSdk { version = release(23) }
+        targetSdk { version = release(37) }
+        versionCode = 1
+        versionName = "1.0"
+    }
+    buildFeatures {
+        compose = true
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 kotlin {
-	compilerOptions {
-		jvmTarget = JvmTarget.JVM_17
-	}
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+    }
 }
 
 dependencies {
-	implementation(project(":shared"))
-	implementation(platform(libs.androidx.compose.bom))
-	implementation(libs.androidx.compose.ui)
-	implementation(libs.androidx.compose.ui.tooling)
-	implementation(libs.androidx.compose.ui.tooling.preview)
-	implementation(libs.androidx.compose.foundation)
-	implementation(libs.androidx.compose.material3)
-	implementation(libs.androidx.activity.compose)
-	implementation(libs.androidx.core.ktx)
+    implementation(project(":shared"))
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.core.ktx)
 }

--- a/demo-app/androidApp/src/main/java/com/svenjacobs/reveal/demo/android/MainActivity.kt
+++ b/demo-app/androidApp/src/main/java/com/svenjacobs/reveal/demo/android/MainActivity.kt
@@ -8,13 +8,13 @@ import com.svenjacobs.reveal.demo.presentation.App
 
 class MainActivity : ComponentActivity() {
 
-	override fun onCreate(savedInstanceState: Bundle?) {
-		super.onCreate(savedInstanceState)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
 
-		WindowCompat.setDecorFitsSystemWindows(window, false)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
-		setContent {
-			App()
-		}
-	}
+        setContent {
+            App()
+        }
+    }
 }

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -1,27 +1,27 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 plugins {
-	alias(libs.plugins.android.application) apply false
-	alias(libs.plugins.android.library) apply false
-	alias(libs.plugins.android.multiplatform.library) apply false
-	alias(libs.plugins.jetbrains.kotlin.multiplatform) apply false
-	alias(libs.plugins.jetbrains.compose) apply false
-	alias(libs.plugins.compose.compiler) apply false
-	alias(libs.plugins.ben.manes.versions)
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.android.multiplatform.library) apply false
+    alias(libs.plugins.jetbrains.kotlin.multiplatform) apply false
+    alias(libs.plugins.jetbrains.compose) apply false
+    alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.ben.manes.versions)
 }
 
 tasks.register("clean", Delete::class) {
-	delete(rootProject.layout.buildDirectory)
+    delete(rootProject.layout.buildDirectory)
 }
 
 tasks.withType<DependencyUpdatesTask> {
 
-	fun isNonStable(version: String) =
-		listOf("alpha", "beta", "rc", "eap", "-m", ".m", "-a", "dev").any {
-			version.lowercase().contains(it)
-		}
+    fun isNonStable(version: String) =
+        listOf("alpha", "beta", "rc", "eap", "-m", ".m", "-a", "dev").any {
+            version.lowercase().contains(it)
+        }
 
-	rejectVersionIf {
-		isNonStable(candidate.version) && !isNonStable(currentVersion)
-	}
+    rejectVersionIf {
+        isNonStable(candidate.version) && !isNonStable(currentVersion)
+    }
 }

--- a/demo-app/desktopApp/build.gradle.kts
+++ b/demo-app/desktopApp/build.gradle.kts
@@ -1,31 +1,31 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
-	alias(libs.plugins.jetbrains.kotlin.multiplatform)
-	alias(libs.plugins.jetbrains.compose)
-	alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.jetbrains.kotlin.multiplatform)
+    alias(libs.plugins.jetbrains.compose)
+    alias(libs.plugins.compose.compiler)
 }
 
 kotlin {
-	jvm()
-	sourceSets {
-		val jvmMain by getting {
-			dependencies {
-				implementation(compose.desktop.currentOs)
-				implementation(project(":shared"))
-			}
-		}
-	}
+    jvm()
+    sourceSets {
+        val jvmMain by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
+                implementation(project(":shared"))
+            }
+        }
+    }
 }
 
 compose.desktop {
-	application {
-		mainClass = "MainKt"
+    application {
+        mainClass = "MainKt"
 
-		nativeDistributions {
-			targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
-			packageName = "KotlinMultiplatformComposeDesktopApplication"
-			packageVersion = "1.0.0"
-		}
-	}
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageName = "KotlinMultiplatformComposeDesktopApplication"
+            packageVersion = "1.0.0"
+        }
+    }
 }

--- a/demo-app/desktopApp/src/jvmMain/kotlin/main.kt
+++ b/demo-app/desktopApp/src/jvmMain/kotlin/main.kt
@@ -3,7 +3,7 @@ import androidx.compose.ui.window.application
 import com.svenjacobs.reveal.demo.presentation.App
 
 fun main() = application {
-	Window(onCloseRequest = ::exitApplication) {
-		App()
-	}
+    Window(onCloseRequest = ::exitApplication) {
+        App()
+    }
 }

--- a/demo-app/gradle.properties
+++ b/demo-app/gradle.properties
@@ -8,6 +8,5 @@ android.nonTransitiveRClass=true
 #MPP
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableCInteropCommonization=true
-kotlin.mpp.androidSourceSetLayoutVersion=2
 #Compose
 org.jetbrains.compose.experimental.uikit.enabled=true

--- a/demo-app/settings.gradle.kts
+++ b/demo-app/settings.gradle.kts
@@ -1,34 +1,34 @@
 pluginManagement {
-	repositories {
-		google()
-		gradlePluginPortal()
-		mavenCentral()
-	}
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+    }
 }
 
 plugins {
-	id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {
-	repositories {
-		google()
-		mavenCentral()
-		mavenLocal()
-	}
+    repositories {
+        google()
+        mavenCentral()
+        mavenLocal()
+    }
 }
 
 rootProject.name = "RevealDemo"
 include(
-	":shared",
-	":androidApp",
-	":desktopApp",
+    ":shared",
+    ":androidApp",
+    ":desktopApp",
 )
 
 includeBuild("../") {
-	name = "reveal-root"
-	dependencySubstitution {
-		substitute(module("reveal:core")).using(project(":reveal-core"))
-		substitute(module("reveal:shapes")).using(project(":reveal-shapes"))
-	}
+    name = "reveal-root"
+    dependencySubstitution {
+        substitute(module("reveal:core")).using(project(":reveal-core"))
+        substitute(module("reveal:shapes")).using(project(":reveal-shapes"))
+    }
 }

--- a/demo-app/shared/build.gradle.kts
+++ b/demo-app/shared/build.gradle.kts
@@ -4,58 +4,58 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-	alias(libs.plugins.jetbrains.kotlin.multiplatform)
-	alias(libs.plugins.android.multiplatform.library)
-	alias(libs.plugins.jetbrains.compose)
-	alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.jetbrains.kotlin.multiplatform)
+    alias(libs.plugins.android.multiplatform.library)
+    alias(libs.plugins.jetbrains.compose)
+    alias(libs.plugins.compose.compiler)
 }
 
 kotlin {
-	jvmToolchain(17)
+    jvmToolchain(17)
 
-	applyDefaultHierarchyTemplate()
+    applyDefaultHierarchyTemplate()
 
-	jvm("desktop")
+    jvm("desktop")
 
-	android {
-		namespace = "com.svenjacobs.reveal.demo"
-		minSdk { version = release(23) }
-		compileSdk { version = release(36) }
-		compilerOptions {
-			jvmTarget.set(JvmTarget.JVM_17)
-		}
-		withHostTest {
-			targetSdk {
-				version = release(36)
-			}
-		}
-	}
+    android {
+        namespace = "com.svenjacobs.reveal.demo"
+        minSdk { version = release(23) }
+        compileSdk { version = release(36) }
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+        withHostTest {
+            targetSdk {
+                version = release(36)
+            }
+        }
+    }
 
-	listOf(
-		iosArm64(),
-		iosSimulatorArm64(),
-	).forEach {
-		it.binaries.framework {
-			baseName = "shared"
-		}
-	}
+    listOf(
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach {
+        it.binaries.framework {
+            baseName = "shared"
+        }
+    }
 
-	sourceSets {
-		commonMain.dependencies {
-			implementation(libs.compose.multiplatform.runtime)
-			implementation(libs.compose.multiplatform.foundation)
-			implementation(libs.compose.multiplatform.material3)
-			implementation(libs.compose.multiplatform.material.icons.extended)
-			implementation(libs.compose.multiplatform.components.resources)
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.compose.multiplatform.runtime)
+            implementation(libs.compose.multiplatform.foundation)
+            implementation(libs.compose.multiplatform.material3)
+            implementation(libs.compose.multiplatform.material.icons.extended)
+            implementation(libs.compose.multiplatform.components.resources)
 
-			//noinspection UseTomlInstead
-			implementation("reveal:core")
-			//noinspection UseTomlInstead
-			implementation("reveal:shapes")
-		}
+            //noinspection UseTomlInstead
+            implementation("reveal:core")
+            //noinspection UseTomlInstead
+            implementation("reveal:shapes")
+        }
 
-		commonTest.dependencies {
-			implementation(kotlin("test"))
-		}
-	}
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+    }
 }

--- a/demo-app/shared/src/commonMain/kotlin/com/svenjacobs/reveal/demo/presentation/App.kt
+++ b/demo-app/shared/src/commonMain/kotlin/com/svenjacobs/reveal/demo/presentation/App.kt
@@ -8,14 +8,14 @@ import com.svenjacobs.reveal.demo.presentation.theme.DemoTheme
 
 @Composable
 fun App(modifier: Modifier = Modifier) {
-	DemoTheme {
-		val revealCanvasState = rememberRevealCanvasState()
+    DemoTheme {
+        val revealCanvasState = rememberRevealCanvasState()
 
-		RevealCanvas(
-			revealCanvasState = revealCanvasState,
-			modifier = modifier,
-		) {
-			MainScreen(revealCanvasState = revealCanvasState)
-		}
-	}
+        RevealCanvas(
+            revealCanvasState = revealCanvasState,
+            modifier = modifier,
+        ) {
+            MainScreen(revealCanvasState = revealCanvasState)
+        }
+    }
 }

--- a/demo-app/shared/src/commonMain/kotlin/com/svenjacobs/reveal/demo/presentation/MainScreen.kt
+++ b/demo-app/shared/src/commonMain/kotlin/com/svenjacobs/reveal/demo/presentation/MainScreen.kt
@@ -40,112 +40,112 @@ private enum class Keys { Fab, Explanation }
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun MainScreen(revealCanvasState: RevealCanvasState, modifier: Modifier = Modifier) {
-	val scope = rememberCoroutineScope()
-	val revealState = rememberRevealState()
+    val scope = rememberCoroutineScope()
+    val revealState = rememberRevealState()
 
-	LaunchedEffect(Unit) {
-		if (revealState.isVisible) return@LaunchedEffect
-		delay(2.seconds)
-		revealState.reveal(Keys.Fab)
-	}
+    LaunchedEffect(Unit) {
+        if (revealState.isVisible) return@LaunchedEffect
+        delay(2.seconds)
+        revealState.reveal(Keys.Fab)
+    }
 
-	Reveal(
-		onOverlayClick = { scope.launch { revealState.hide() } },
-		modifier = modifier,
-		revealCanvasState = revealCanvasState,
-		revealState = revealState,
-		overlayContent = { key -> RevealOverlayContent(key) },
-	) {
-		Scaffold(
-			modifier = Modifier.fillMaxSize(),
-			topBar = {
-				CenterAlignedTopAppBar(
-					title = { Text("Reveal Demo") },
-				)
-			},
-			floatingActionButton = {
-				FloatingActionButton(
-					modifier = Modifier.revealable(
-						key = Keys.Fab,
-						shape = RevealShape.RoundRect(16.dp),
-						borderStroke = BorderStroke(2.dp, Color.DarkGray),
-						onClick = OnClick.Listener {
-							scope.launch { revealState.reveal(Keys.Explanation) }
-						},
-					),
-					onClick = {
-						scope.launch { revealState.reveal(Keys.Explanation) }
-					},
-				) {
-					Icon(
-						Icons.Filled.Add,
-						contentDescription = null,
-					)
-				}
-			},
-		) { contentPadding ->
-			Column(
-				modifier = Modifier
-					.fillMaxSize()
-					.padding(contentPadding)
-					.padding(horizontal = 16.dp),
-				horizontalAlignment = Alignment.CenterHorizontally,
-			) {
-				Text(
-					modifier = Modifier
-						.padding(top = 16.dp)
-						.revealable(
-							key = Keys.Explanation,
-							borderStroke = BorderStroke(2.dp, Color.DarkGray),
-							onClick = OnClick.Listener {
-								scope.launch { revealState.hide() }
-							},
-						),
-					text = "Reveal is a lightweight, simple reveal effect (also known as " +
-						"coach mark or onboarding) library for Compose Multiplatform.",
-					style = MaterialTheme.typography.bodyLarge,
-					textAlign = TextAlign.Justify,
-				)
-			}
-		}
-	}
+    Reveal(
+        onOverlayClick = { scope.launch { revealState.hide() } },
+        modifier = modifier,
+        revealCanvasState = revealCanvasState,
+        revealState = revealState,
+        overlayContent = { key -> RevealOverlayContent(key) },
+    ) {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = { Text("Reveal Demo") },
+                )
+            },
+            floatingActionButton = {
+                FloatingActionButton(
+                    modifier = Modifier.revealable(
+                        key = Keys.Fab,
+                        shape = RevealShape.RoundRect(16.dp),
+                        borderStroke = BorderStroke(2.dp, Color.DarkGray),
+                        onClick = OnClick.Listener {
+                            scope.launch { revealState.reveal(Keys.Explanation) }
+                        },
+                    ),
+                    onClick = {
+                        scope.launch { revealState.reveal(Keys.Explanation) }
+                    },
+                ) {
+                    Icon(
+                        Icons.Filled.Add,
+                        contentDescription = null,
+                    )
+                }
+            },
+        ) { contentPadding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(contentPadding)
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .revealable(
+                            key = Keys.Explanation,
+                            borderStroke = BorderStroke(2.dp, Color.DarkGray),
+                            onClick = OnClick.Listener {
+                                scope.launch { revealState.hide() }
+                            },
+                        ),
+                    text = "Reveal is a lightweight, simple reveal effect (also known as " +
+                        "coach mark or onboarding) library for Compose Multiplatform.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Justify,
+                )
+            }
+        }
+    }
 }
 
 @Composable
 private fun RevealOverlayScope.RevealOverlayContent(key: Key) {
-	when (key) {
-		Keys.Fab -> OverlayText(
-			modifier = Modifier.align(
-				horizontalArrangement = RevealOverlayArrangement.Start,
-			),
-			text = "Click button to get started",
-			arrow = Arrow.end(anchorToReveal = true),
-		)
+    when (key) {
+        Keys.Fab -> OverlayText(
+            modifier = Modifier.align(
+                horizontalArrangement = RevealOverlayArrangement.Start,
+            ),
+            text = "Click button to get started",
+            arrow = Arrow.end(anchorToReveal = true),
+        )
 
-		Keys.Explanation -> OverlayText(
-			modifier = Modifier.align(
-				verticalArrangement = RevealOverlayArrangement.Bottom,
-			),
-			text = "Actually we already started. This was an example of the reveal effect.",
-			arrow = Arrow.top(anchorToReveal = true),
-		)
-	}
+        Keys.Explanation -> OverlayText(
+            modifier = Modifier.align(
+                verticalArrangement = RevealOverlayArrangement.Bottom,
+            ),
+            text = "Actually we already started. This was an example of the reveal effect.",
+            arrow = Arrow.top(anchorToReveal = true),
+        )
+    }
 }
 
 @Composable
 private fun OverlayText(text: String, arrow: Arrow, modifier: Modifier = Modifier) {
-	Balloon(
-		modifier = modifier.padding(8.dp),
-		arrow = arrow,
-		backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
-		elevation = 2.dp,
-	) {
-		Text(
-			modifier = Modifier.padding(8.dp),
-			text = text,
-			style = MaterialTheme.typography.labelLarge,
-			textAlign = TextAlign.Center,
-		)
-	}
+    Balloon(
+        modifier = modifier.padding(8.dp),
+        arrow = arrow,
+        backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+        elevation = 2.dp,
+    ) {
+        Text(
+            modifier = Modifier.padding(8.dp),
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            textAlign = TextAlign.Center,
+        )
+    }
 }
 

--- a/demo-app/shared/src/commonMain/kotlin/com/svenjacobs/reveal/demo/presentation/theme/Theme.kt
+++ b/demo-app/shared/src/commonMain/kotlin/com/svenjacobs/reveal/demo/presentation/theme/Theme.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 fun DemoTheme(content: @Composable () -> Unit) {
-	MaterialTheme(
-		content = content,
-	)
+    MaterialTheme(
+        content = content,
+    )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ kotlin.code.style=official
 # MPP
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableCInteropCommonization=true
-kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.ignoreDisabledTargets=true
 # Compose Multiplatform
 org.jetbrains.compose.experimental.uikit.enabled=true

--- a/reveal-common/build.gradle.kts
+++ b/reveal-common/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-	alias(libs.plugins.android.multiplatform.library)
-	id("convention.multiplatform")
-	id("convention.publication")
+    alias(libs.plugins.android.multiplatform.library)
+    id("convention.multiplatform")
+    id("convention.publication")
 }
 
 val baseName by extra { "reveal-common" }
@@ -11,30 +11,30 @@ val androidMinSdk: Int by rootProject.extra
 val androidCompileSdk: Int by rootProject.extra
 
 kotlin {
-	android {
-		namespace = "com.svenjacobs.reveal.common"
+    android {
+        namespace = "com.svenjacobs.reveal.common"
 
-		compileSdk { version = release(androidCompileSdk) }
-		minSdk { version = release(androidMinSdk) }
+        compileSdk { version = release(androidCompileSdk) }
+        minSdk { version = release(androidMinSdk) }
 
-		aarMetadata {
-			minCompileSdk = androidMinSdk
-		}
+        aarMetadata {
+            minCompileSdk = androidMinSdk
+        }
 
-		withHostTest {}
-	}
+        withHostTest {}
+    }
 
-	sourceSets {
-		commonMain.dependencies {
-			implementation(libs.compose.multiplatform.runtime)
-			implementation(libs.compose.multiplatform.foundation)
-		}
-		commonTest.dependencies {
-			implementation(kotlin("test"))
-		}
-	}
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.compose.multiplatform.runtime)
+            implementation(libs.compose.multiplatform.foundation)
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+    }
 }
 
 dependencies {
-	lintChecks(libs.slack.compose.lint.checks)
+    lintChecks(libs.slack.compose.lint.checks)
 }

--- a/reveal-common/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayArrowAnchor.kt
+++ b/reveal-common/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayArrowAnchor.kt
@@ -42,5 +42,6 @@ public class RevealOverlayArrowAnchor {
  *
  * @see RevealOverlayArrowAnchor
  */
+@Suppress("ComposeCompositionLocalUsage")
 public val LocalRevealOverlayArrowAnchor: ProvidableCompositionLocal<RevealOverlayArrowAnchor?> =
     compositionLocalOf { null }

--- a/reveal-common/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayArrowAnchor.kt
+++ b/reveal-common/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayArrowAnchor.kt
@@ -29,11 +29,11 @@ import androidx.compose.runtime.setValue
 @Stable
 public class RevealOverlayArrowAnchor {
 
-	/** Horizontal center-relative offset; non-null for [RevealOverlayArrangement.Vertical] alignments. */
-	public var offsetX: Float? by mutableStateOf(null)
+    /** Horizontal center-relative offset; non-null for [RevealOverlayArrangement.Vertical] alignments. */
+    public var offsetX: Float? by mutableStateOf(null)
 
-	/** Vertical center-relative offset; non-null for [RevealOverlayArrangement.Horizontal] alignments. */
-	public var offsetY: Float? by mutableStateOf(null)
+    /** Vertical center-relative offset; non-null for [RevealOverlayArrangement.Horizontal] alignments. */
+    public var offsetY: Float? by mutableStateOf(null)
 }
 
 /**
@@ -43,4 +43,4 @@ public class RevealOverlayArrowAnchor {
  * @see RevealOverlayArrowAnchor
  */
 public val LocalRevealOverlayArrowAnchor: ProvidableCompositionLocal<RevealOverlayArrowAnchor?> =
-	compositionLocalOf { null }
+    compositionLocalOf { null }

--- a/reveal-common/src/commonMain/kotlin/com/svenjacobs/reveal/common/inserter/InPlaceRevealOverlayInserter.kt
+++ b/reveal-common/src/commonMain/kotlin/com/svenjacobs/reveal/common/inserter/InPlaceRevealOverlayInserter.kt
@@ -11,10 +11,10 @@ public typealias DefaultRevealOverlayInserter = InPlaceRevealOverlayInserter
  */
 public class InPlaceRevealOverlayInserter : RevealOverlayInserter {
 
-	@Composable
-	override fun Container(content: @Composable () -> Unit) {
-		content()
-	}
+    @Composable
+    override fun Container(content: @Composable () -> Unit) {
+        content()
+    }
 
-	override val revealableOffset: DpOffset = DpOffset.Zero
+    override val revealableOffset: DpOffset = DpOffset.Zero
 }

--- a/reveal-common/src/commonMain/kotlin/com/svenjacobs/reveal/common/inserter/RevealOverlayInserter.kt
+++ b/reveal-common/src/commonMain/kotlin/com/svenjacobs/reveal/common/inserter/RevealOverlayInserter.kt
@@ -10,16 +10,16 @@ import androidx.compose.ui.unit.DpOffset
 @Stable
 public interface RevealOverlayInserter {
 
-	/**
-	 * Container which is used to insert the overlay.
-	 *
-	 * @param content Overlay composable
-	 */
-	@Composable
-	public fun Container(content: @Composable () -> Unit)
+    /**
+     * Container which is used to insert the overlay.
+     *
+     * @param content Overlay composable
+     */
+    @Composable
+    public fun Container(content: @Composable () -> Unit)
 
-	/**
-	 * Additional offset that is applied to all revealables when this inserter is used.
-	 */
-	public val revealableOffset: DpOffset
+    /**
+     * Additional offset that is applied to all revealables when this inserter is used.
+     */
+    public val revealableOffset: DpOffset
 }

--- a/reveal-common/src/commonMain/kotlin/com/svenjacobs/reveal/common/internal/log/Logger.kt
+++ b/reveal-common/src/commonMain/kotlin/com/svenjacobs/reveal/common/internal/log/Logger.kt
@@ -6,13 +6,13 @@ package com.svenjacobs.reveal.common.internal.log
  */
 public object Logger {
 
-	public fun interface Adapter {
-		public fun d(message: String, tag: String)
-	}
+    public fun interface Adapter {
+        public fun d(message: String, tag: String)
+    }
 
-	public var adapter: Adapter? = null
+    public var adapter: Adapter? = null
 
-	public fun d(message: String, tag: String = "Reveal") {
-		adapter?.d(message, tag)
-	}
+    public fun d(message: String, tag: String = "Reveal") {
+        adapter?.d(message, tag)
+    }
 }

--- a/reveal-compat-android/build.gradle.kts
+++ b/reveal-compat-android/build.gradle.kts
@@ -1,16 +1,16 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-	alias(libs.plugins.android.library)
-	alias(libs.plugins.compose.compiler)
-	`maven-publish`
-	id("convention.publication")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.compose.compiler)
+    `maven-publish`
+    id("convention.publication")
 }
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 val publicationName by extra { "Reveal (Compat Android)" }
@@ -19,82 +19,82 @@ val androidMinSdk: Int by rootProject.extra
 val androidCompileSdk: Int by rootProject.extra
 
 android {
-	namespace = "com.svenjacobs.reveal.compat.android"
-	compileSdk { version = release(androidCompileSdk) }
+    namespace = "com.svenjacobs.reveal.compat.android"
+    compileSdk { version = release(androidCompileSdk) }
 
-	defaultConfig {
-		minSdk { version = release(androidMinSdk) }
+    defaultConfig {
+        minSdk { version = release(androidMinSdk) }
 
-		aarMetadata {
-			minCompileSdk = androidMinSdk
-		}
+        aarMetadata {
+            minCompileSdk = androidMinSdk
+        }
 
-		testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-	}
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
 
-	buildTypes {
-		release {
-			isMinifyEnabled = false
-			proguardFiles(
-				getDefaultProguardFile("proguard-android-optimize.txt"),
-				"proguard-rules.pro",
-			)
-		}
-	}
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
 
-	compileOptions {
-		sourceCompatibility = JavaVersion.VERSION_11
-		targetCompatibility = JavaVersion.VERSION_11
-	}
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
 
-	buildFeatures {
-		compose = true
-	}
+    buildFeatures {
+        compose = true
+    }
 
-	publishing {
-		singleVariant("release") {
-			withSourcesJar()
-		}
-	}
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 
-	lint {
-		baseline = file("lint-baseline.xml")
-	}
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 kotlin {
-	explicitApi()
-	compilerOptions {
-		jvmTarget = JvmTarget.JVM_11
-	}
+    explicitApi()
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_11
+    }
 }
 
 publishing {
-	publications {
-		register<MavenPublication>("release") {
-			afterEvaluate {
-				from(components["release"])
-			}
-		}
-	}
+    publications {
+        register<MavenPublication>("release") {
+            afterEvaluate {
+                from(components["release"])
+            }
+        }
+    }
 }
 
 dependencies {
-	api(project(":reveal-common"))
+    api(project(":reveal-common"))
 
-	val composeBom = platform(libs.androidx.compose.bom)
+    val composeBom = platform(libs.androidx.compose.bom)
 
-	implementation(composeBom)
-	api(libs.androidx.compose.foundation)
-	api(libs.androidx.compose.ui)
+    implementation(composeBom)
+    api(libs.androidx.compose.foundation)
+    api(libs.androidx.compose.ui)
 
-	debugApi(libs.androidx.compose.ui.tooling)
+    debugApi(libs.androidx.compose.ui.tooling)
 
-	testImplementation(libs.junit)
-	androidTestImplementation(composeBom)
-	androidTestImplementation(libs.androidx.test.ext.junit)
-	androidTestImplementation(libs.androidx.test.espresso.core)
-	androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.junit)
+    androidTestImplementation(composeBom)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 
-	lintChecks(libs.slack.compose.lint.checks)
+    lintChecks(libs.slack.compose.lint.checks)
 }

--- a/reveal-compat-android/src/main/kotlin/com/svenjacobs/reveal/compat/android/inserter/Fullscreen.kt
+++ b/reveal-compat-android/src/main/kotlin/com/svenjacobs/reveal/compat/android/inserter/Fullscreen.kt
@@ -18,35 +18,37 @@ import androidx.compose.ui.platform.LocalContext
  */
 @Composable
 internal fun Fullscreen(content: @Composable () -> Unit) {
-	val context = LocalContext.current
-	val compositionContext = rememberCompositionContext()
-	val composeView = remember {
-		ComposeView(context).apply {
-			id = View.generateViewId()
-			layoutParams = ViewGroup.LayoutParams(
-				ViewGroup.LayoutParams.MATCH_PARENT,
-				ViewGroup.LayoutParams.MATCH_PARENT,
-			)
-			setParentCompositionContext(compositionContext)
-			setContent(content)
-		}
-	}
+    val context = LocalContext.current
+    val compositionContext = rememberCompositionContext()
+    val composeView = remember {
+        ComposeView(context).apply {
+            id = View.generateViewId()
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            setParentCompositionContext(compositionContext)
+            setContent(content)
+        }
+    }
 
-	DisposableEffect(Unit) {
-		val container =
-			context.findActivity()?.window?.decorView?.findViewById<ViewGroup>(android.R.id.content)
-				?: throw IllegalStateException("Root content view with ID android.R.id.content not found")
+    DisposableEffect(Unit) {
+        val container =
+            context.findActivity()?.window?.decorView?.findViewById<ViewGroup>(android.R.id.content)
+                ?: throw IllegalStateException(
+                    "Root content view with ID android.R.id.content not found",
+                )
 
-		container.addView(composeView)
+        container.addView(composeView)
 
-		onDispose {
-			container.removeView(composeView)
-		}
-	}
+        onDispose {
+            container.removeView(composeView)
+        }
+    }
 }
 
 private tailrec fun Context.findActivity(): Activity? = when (this) {
-	is Activity -> this
-	is ContextWrapper -> baseContext.findActivity()
-	else -> null
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
 }

--- a/reveal-compat-android/src/main/kotlin/com/svenjacobs/reveal/compat/android/inserter/FullscreenRevealOverlayInserter.kt
+++ b/reveal-compat-android/src/main/kotlin/com/svenjacobs/reveal/compat/android/inserter/FullscreenRevealOverlayInserter.kt
@@ -25,11 +25,11 @@ import com.svenjacobs.reveal.common.inserter.RevealOverlayInserter
  * @see InPlaceRevealOverlayInserter
  */
 public class FullscreenRevealOverlayInserter(
-	override val revealableOffset: DpOffset = DpOffset.Zero,
+    override val revealableOffset: DpOffset = DpOffset.Zero,
 ) : RevealOverlayInserter {
 
-	@Composable
-	override fun Container(content: @Composable () -> Unit) {
-		Fullscreen(content = content)
-	}
+    @Composable
+    override fun Container(content: @Composable () -> Unit) {
+        Fullscreen(content = content)
+    }
 }

--- a/reveal-core/build.gradle.kts
+++ b/reveal-core/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-	alias(libs.plugins.android.multiplatform.library)
-	id("convention.multiplatform")
-	id("convention.publication")
+    alias(libs.plugins.android.multiplatform.library)
+    id("convention.multiplatform")
+    id("convention.publication")
 }
 
 val baseName by extra { "reveal-core" }
@@ -12,30 +12,30 @@ val androidTargetSdk: Int by rootProject.extra
 val androidCompileSdk: Int by rootProject.extra
 
 kotlin {
-	android {
-		namespace = "com.svenjacobs.reveal"
-		compileSdk { version = release(androidCompileSdk) }
-		minSdk { version = release(androidMinSdk) }
+    android {
+        namespace = "com.svenjacobs.reveal"
+        compileSdk { version = release(androidCompileSdk) }
+        minSdk { version = release(androidMinSdk) }
 
-		aarMetadata {
-			minCompileSdk = androidMinSdk
-		}
+        aarMetadata {
+            minCompileSdk = androidMinSdk
+        }
 
-		withHostTest {}
-	}
+        withHostTest {}
+    }
 
-	sourceSets {
-		commonMain.dependencies {
-			api(project(":reveal-common"))
-			implementation(libs.compose.multiplatform.runtime)
-			implementation(libs.compose.multiplatform.foundation)
-		}
-		commonTest.dependencies {
-			implementation(kotlin("test"))
-		}
-	}
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":reveal-common"))
+            implementation(libs.compose.multiplatform.runtime)
+            implementation(libs.compose.multiplatform.foundation)
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+    }
 }
 
 dependencies {
-	lintChecks(libs.slack.compose.lint.checks)
+    lintChecks(libs.slack.compose.lint.checks)
 }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Modifiers.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Modifiers.kt
@@ -12,17 +12,17 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 
 public sealed interface OnClick {
-	/**
-	 * Clicks on Revealable are handled by the specified handler.
-	 */
-	@Immutable
-	public data class Listener(val listener: OnClickListener) : OnClick
+    /**
+     * Clicks on Revealable are handled by the specified handler.
+     */
+    @Immutable
+    public data class Listener(val listener: OnClickListener) : OnClick
 
-	/**
-	 * Clicks on Revealable are not handled by Reveal and passed through to underlying
-	 * composables.
-	 */
-	public data object Passthrough : OnClick
+    /**
+     * Clicks on Revealable are not handled by Reveal and passed through to underlying
+     * composables.
+     */
+    public data object Passthrough : OnClick
 }
 
 /**
@@ -50,21 +50,21 @@ public sealed interface OnClick {
  * @see Key
  */
 public fun Modifier.revealable(
-	key: Key,
-	state: RevealState,
-	shape: RevealShape = RevealShape.RoundRect(4.dp),
-	padding: PaddingValues = PaddingValues(8.dp),
-	borderStroke: BorderStroke? = null,
-	onClick: OnClick? = null,
+    key: Key,
+    state: RevealState,
+    shape: RevealShape = RevealShape.RoundRect(4.dp),
+    padding: PaddingValues = PaddingValues(8.dp),
+    borderStroke: BorderStroke? = null,
+    onClick: OnClick? = null,
 ): Modifier = this.then(
-	Modifier.revealable(
-		state = state,
-		keys = listOf(key),
-		shape = shape,
-		padding = padding,
-		borderStroke = borderStroke,
-		onClick = onClick,
-	),
+    Modifier.revealable(
+        state = state,
+        keys = listOf(key),
+        shape = shape,
+        padding = padding,
+        borderStroke = borderStroke,
+        onClick = onClick,
+    ),
 )
 
 /**
@@ -92,21 +92,21 @@ public fun Modifier.revealable(
  * @see Key
  */
 public fun Modifier.revealable(
-	vararg keys: Key,
-	state: RevealState,
-	shape: RevealShape = RevealShape.RoundRect(4.dp),
-	padding: PaddingValues = PaddingValues(8.dp),
-	borderStroke: BorderStroke? = null,
-	onClick: OnClick? = null,
+    vararg keys: Key,
+    state: RevealState,
+    shape: RevealShape = RevealShape.RoundRect(4.dp),
+    padding: PaddingValues = PaddingValues(8.dp),
+    borderStroke: BorderStroke? = null,
+    onClick: OnClick? = null,
 ): Modifier = this.then(
-	Modifier.revealable(
-		state = state,
-		keys = keys.toList(),
-		shape = shape,
-		padding = padding,
-		borderStroke = borderStroke,
-		onClick = onClick,
-	),
+    Modifier.revealable(
+        state = state,
+        keys = keys.toList(),
+        shape = shape,
+        padding = padding,
+        borderStroke = borderStroke,
+        onClick = onClick,
+    ),
 )
 
 /**
@@ -134,37 +134,37 @@ public fun Modifier.revealable(
  * @see Key
  */
 public fun Modifier.revealable(
-	keys: Iterable<Key>,
-	state: RevealState,
-	shape: RevealShape = RevealShape.RoundRect(4.dp),
-	padding: PaddingValues = PaddingValues(8.dp),
-	borderStroke: BorderStroke? = null,
-	onClick: OnClick? = null,
+    keys: Iterable<Key>,
+    state: RevealState,
+    shape: RevealShape = RevealShape.RoundRect(4.dp),
+    padding: PaddingValues = PaddingValues(8.dp),
+    borderStroke: BorderStroke? = null,
+    onClick: OnClick? = null,
 ): Modifier = this.then(
-	Modifier
-		.onGloballyPositioned { layoutCoordinates ->
-			keys.forEach { key ->
-				state.addRevealable(
-					Revealable(
-						key = key,
-						shape = shape,
-						padding = padding,
-						borderStroke = borderStroke,
-						layout = Revealable.Layout(
-							offset = layoutCoordinates.positionInRoot(),
-							size = layoutCoordinates.size.toSize(),
-						),
-						onClick = onClick,
-					),
-				)
-			}
-		}
-		.composed {
-			DisposableEffect(Unit) {
-				onDispose {
-					keys.forEach(state::removeRevealable)
-				}
-			}
-			this
-		},
+    Modifier
+        .onGloballyPositioned { layoutCoordinates ->
+            keys.forEach { key ->
+                state.addRevealable(
+                    Revealable(
+                        key = key,
+                        shape = shape,
+                        padding = padding,
+                        borderStroke = borderStroke,
+                        layout = Revealable.Layout(
+                            offset = layoutCoordinates.positionInRoot(),
+                            size = layoutCoordinates.size.toSize(),
+                        ),
+                        onClick = onClick,
+                    ),
+                )
+            }
+        }
+        .composed {
+            DisposableEffect(Unit) {
+                onDispose {
+                    keys.forEach(state::removeRevealable)
+                }
+            }
+            this
+        },
 )

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Reveal.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Reveal.kt
@@ -75,132 +75,132 @@ import com.svenjacobs.reveal.effect.dim.DimRevealOverlayEffect
  */
 @Composable
 public fun Reveal(
-	revealCanvasState: RevealCanvasState,
-	modifier: Modifier = Modifier,
-	onRevealableClick: OnClickListener = {},
-	onOverlayClick: OnClickListener = {},
-	revealState: RevealState = rememberRevealState(),
-	overlayEffect: RevealOverlayEffect = DimRevealOverlayEffect(),
-	overlayContent: @Composable (RevealOverlayScope.(key: Key) -> Unit) = {},
-	content: @Composable (RevealScope.() -> Unit),
+    revealCanvasState: RevealCanvasState,
+    modifier: Modifier = Modifier,
+    onRevealableClick: OnClickListener = {},
+    onOverlayClick: OnClickListener = {},
+    revealState: RevealState = rememberRevealState(),
+    overlayEffect: RevealOverlayEffect = DimRevealOverlayEffect(),
+    overlayContent: @Composable (RevealOverlayScope.(key: Key) -> Unit) = {},
+    content: @Composable (RevealScope.() -> Unit),
 ) {
-	val animatedOverlayAlpha by animateFloatAsState(
-		targetValue = if (revealState.isVisible) 1.0f else 0.0f,
-		animationSpec = overlayEffect.alphaAnimationSpec,
-		finishedListener = { alpha ->
-			if (alpha == 0.0f) {
-				revealState.onHideAnimationFinished()
-			}
-		},
-		label = "animatedOverlayAlpha",
-	)
-	val layoutDirection = LocalLayoutDirection.current
-	val density = LocalDensity.current
+    val animatedOverlayAlpha by animateFloatAsState(
+        targetValue = if (revealState.isVisible) 1.0f else 0.0f,
+        animationSpec = overlayEffect.alphaAnimationSpec,
+        finishedListener = { alpha ->
+            if (alpha == 0.0f) {
+                revealState.onHideAnimationFinished()
+            }
+        },
+        label = "animatedOverlayAlpha",
+    )
+    val layoutDirection = LocalLayoutDirection.current
+    val density = LocalDensity.current
 
-	val currentRevealable = remember {
-		derivedStateOf {
-			revealState.currentRevealable?.toActual(
-				density = density,
-				layoutDirection = layoutDirection,
-				additionalOffset = revealCanvasState.revealableOffset,
-			)
-		}
-	}
+    val currentRevealable = remember {
+        derivedStateOf {
+            revealState.currentRevealable?.toActual(
+                density = density,
+                layoutDirection = layoutDirection,
+                additionalOffset = revealCanvasState.revealableOffset,
+            )
+        }
+    }
 
-	val rev by rememberUpdatedState(currentRevealable.value)
+    val rev by rememberUpdatedState(currentRevealable.value)
 
-	val clickModifier = when {
-		revealState.isVisible -> Modifier.pointerInput(Unit) {
-			awaitEachGesture {
-				val down = awaitFirstDown(pass = PointerEventPass.Initial)
-				if (rev?.onClick !is OnClick.Passthrough) {
-					down.consume()
-				}
+    val clickModifier = when {
+        revealState.isVisible -> Modifier.pointerInput(Unit) {
+            awaitEachGesture {
+                val down = awaitFirstDown(pass = PointerEventPass.Initial)
+                if (rev?.onClick !is OnClick.Passthrough) {
+                    down.consume()
+                }
 
-				val up = waitForUpOrCancellation(pass = PointerEventPass.Initial)
-					?: return@awaitEachGesture
+                val up = waitForUpOrCancellation(pass = PointerEventPass.Initial)
+                    ?: return@awaitEachGesture
 
-				rev?.key?.let(
-					if (rev?.area?.contains(up.position) == true) {
-						// pass through touches in the area on top of revealable
-						if (rev?.onClick is OnClick.Passthrough) {
-							return@awaitEachGesture
-						} else {
-							(rev?.onClick as? OnClick.Listener)?.listener ?: onRevealableClick
-						}
-					} else {
-						onOverlayClick
-					},
-				)
-				
-				up.consume()
-			}
-		}
+                rev?.key?.let(
+                    if (rev?.area?.contains(up.position) == true) {
+                        // pass through touches in the area on top of revealable
+                        if (rev?.onClick is OnClick.Passthrough) {
+                            return@awaitEachGesture
+                        } else {
+                            (rev?.onClick as? OnClick.Listener)?.listener ?: onRevealableClick
+                        }
+                    } else {
+                        onOverlayClick
+                    },
+                )
 
-		else -> Modifier
-	}
+                up.consume()
+            }
+        }
 
-	Box(
-		modifier = modifier
-			.then(clickModifier)
-			.semantics { testTag = "overlay" },
-	) {
-		content(RevealScopeInstance(revealState))
+        else -> Modifier
+    }
 
-		val previousRevealable = remember {
-			derivedStateOf {
-				revealState.previousRevealable?.toActual(
-					density = density,
-					layoutDirection = layoutDirection,
-					additionalOffset = revealCanvasState.revealableOffset,
-				)
-			}
-		}
+    Box(
+        modifier = modifier
+            .then(clickModifier)
+            .semantics { testTag = "overlay" },
+    ) {
+        content(RevealScopeInstance(revealState))
 
-		LaunchedEffect(animatedOverlayAlpha) {
-			@Suppress("ktlint:standard:wrapping")
-			revealCanvasState.overlayContent = when {
-				animatedOverlayAlpha > 0.0f -> ({
-					overlayEffect.Overlay(
-						revealState = revealState,
-						currentRevealable = currentRevealable,
-						previousRevealable = previousRevealable,
-						modifier = Modifier
-							.fillMaxSize()
-							.alpha(animatedOverlayAlpha),
-						content = overlayContent,
-					)
-				})
+        val previousRevealable = remember {
+            derivedStateOf {
+                revealState.previousRevealable?.toActual(
+                    density = density,
+                    layoutDirection = layoutDirection,
+                    additionalOffset = revealCanvasState.revealableOffset,
+                )
+            }
+        }
 
-				else -> null
-			}
-		}
-	}
+        LaunchedEffect(animatedOverlayAlpha) {
+            @Suppress("ktlint:standard:wrapping")
+            revealCanvasState.overlayContent = when {
+                animatedOverlayAlpha > 0.0f -> ({
+                    overlayEffect.Overlay(
+                        revealState = revealState,
+                        currentRevealable = currentRevealable,
+                        previousRevealable = previousRevealable,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .alpha(animatedOverlayAlpha),
+                        content = overlayContent,
+                    )
+                })
 
-	// When the Reveal composable is disposed we need to reset overlayContent or else the effect
-	// might remain on the screen (issue #196).
-	DisposableEffect(Unit) {
-		onDispose {
-			revealCanvasState.overlayContent = null
-		}
-	}
+                else -> null
+            }
+        }
+    }
+
+    // When the Reveal composable is disposed we need to reset overlayContent or else the effect
+    // might remain on the screen (issue #196).
+    DisposableEffect(Unit) {
+        onDispose {
+            revealCanvasState.overlayContent = null
+        }
+    }
 }
 
 public typealias OnClickListener = (key: Key) -> Unit
 
 private fun Revealable.toActual(
-	density: Density,
-	layoutDirection: LayoutDirection,
-	additionalOffset: DpOffset,
+    density: Density,
+    layoutDirection: LayoutDirection,
+    additionalOffset: DpOffset,
 ): ActualRevealable = ActualRevealable(
-	key = key,
-	shape = shape,
-	padding = padding,
-	borderStroke = borderStroke,
-	area = computeArea(
-		density = density,
-		layoutDirection = layoutDirection,
-		additionalOffset = additionalOffset,
-	),
-	onClick = onClick,
+    key = key,
+    shape = shape,
+    padding = padding,
+    borderStroke = borderStroke,
+    area = computeArea(
+        density = density,
+        layoutDirection = layoutDirection,
+        additionalOffset = additionalOffset,
+    ),
+    onClick = onClick,
 )

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealCanvas.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealCanvas.kt
@@ -28,22 +28,22 @@ import com.svenjacobs.reveal.common.inserter.RevealOverlayInserter
  */
 @Composable
 public fun RevealCanvas(
-	revealCanvasState: RevealCanvasState,
-	modifier: Modifier = Modifier,
-	overlayInserter: RevealOverlayInserter = DefaultRevealOverlayInserter(),
-	content: @Composable () -> Unit,
+    revealCanvasState: RevealCanvasState,
+    modifier: Modifier = Modifier,
+    overlayInserter: RevealOverlayInserter = DefaultRevealOverlayInserter(),
+    content: @Composable () -> Unit,
 ) {
-	SideEffect {
-		revealCanvasState.revealableOffset = overlayInserter.revealableOffset
-	}
+    SideEffect {
+        revealCanvasState.revealableOffset = overlayInserter.revealableOffset
+    }
 
-	Box(modifier = modifier) {
-		content()
+    Box(modifier = modifier) {
+        content()
 
-		revealCanvasState.overlayContent?.let { overlayContent ->
-			overlayInserter.Container {
-				overlayContent()
-			}
-		}
-	}
+        revealCanvasState.overlayContent?.let { overlayContent ->
+            overlayInserter.Container {
+                overlayContent()
+            }
+        }
+    }
 }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealCanvasState.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealCanvasState.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.unit.DpOffset
 @Stable
 public class RevealCanvasState public constructor() {
 
-	internal var overlayContent: (@Composable () -> Unit)? by mutableStateOf(null)
-	internal var revealableOffset: DpOffset by mutableStateOf(DpOffset.Zero)
+    internal var overlayContent: (@Composable () -> Unit)? by mutableStateOf(null)
+    internal var revealableOffset: DpOffset by mutableStateOf(DpOffset.Zero)
 }
 
 @Composable

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayArrangement.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayArrangement.kt
@@ -6,98 +6,98 @@ import androidx.compose.ui.unit.LayoutDirection
 
 public object RevealOverlayArrangement {
 
-	public data object Start : Horizontal {
+    public data object Start : Horizontal {
 
-		override fun arrange(
-			revealable: IntRect,
-			space: IntSize,
-			confineHeight: Boolean,
-			layoutDirection: LayoutDirection,
-		): IntRect = IntRect(
-			left = if (layoutDirection == LayoutDirection.Ltr) 0 else revealable.right,
-			top = if (confineHeight) revealable.top else 0,
-			right = if (layoutDirection == LayoutDirection.Ltr) revealable.left else space.width,
-			bottom = if (confineHeight) revealable.bottom else space.height,
-		)
+        override fun arrange(
+            revealable: IntRect,
+            space: IntSize,
+            confineHeight: Boolean,
+            layoutDirection: LayoutDirection,
+        ): IntRect = IntRect(
+            left = if (layoutDirection == LayoutDirection.Ltr) 0 else revealable.right,
+            top = if (confineHeight) revealable.top else 0,
+            right = if (layoutDirection == LayoutDirection.Ltr) revealable.left else space.width,
+            bottom = if (confineHeight) revealable.bottom else space.height,
+        )
 
-		override fun align(size: Int, layout: Int, space: Int): Int = layout - size
-	}
+        override fun align(size: Int, layout: Int, space: Int): Int = layout - size
+    }
 
-	public data object End : Horizontal {
+    public data object End : Horizontal {
 
-		override fun arrange(
-			revealable: IntRect,
-			space: IntSize,
-			confineHeight: Boolean,
-			layoutDirection: LayoutDirection,
-		): IntRect = IntRect(
-			left = if (layoutDirection == LayoutDirection.Ltr) revealable.right else 0,
-			top = if (confineHeight) revealable.top else 0,
-			right = if (layoutDirection == LayoutDirection.Ltr) space.width else revealable.left,
-			bottom = if (confineHeight) revealable.bottom else space.height,
-		)
+        override fun arrange(
+            revealable: IntRect,
+            space: IntSize,
+            confineHeight: Boolean,
+            layoutDirection: LayoutDirection,
+        ): IntRect = IntRect(
+            left = if (layoutDirection == LayoutDirection.Ltr) revealable.right else 0,
+            top = if (confineHeight) revealable.top else 0,
+            right = if (layoutDirection == LayoutDirection.Ltr) space.width else revealable.left,
+            bottom = if (confineHeight) revealable.bottom else space.height,
+        )
 
-		override fun align(size: Int, layout: Int, space: Int): Int = space - layout
-	}
+        override fun align(size: Int, layout: Int, space: Int): Int = space - layout
+    }
 
-	public data object Top : Vertical {
+    public data object Top : Vertical {
 
-		override fun arrange(revealable: IntRect, space: IntSize, confineWidth: Boolean): IntRect =
-			IntRect(
-				left = if (confineWidth) revealable.left else 0,
-				top = 0,
-				right = if (confineWidth) revealable.right else space.width,
-				bottom = revealable.top,
-			)
+        override fun arrange(revealable: IntRect, space: IntSize, confineWidth: Boolean): IntRect =
+            IntRect(
+                left = if (confineWidth) revealable.left else 0,
+                top = 0,
+                right = if (confineWidth) revealable.right else space.width,
+                bottom = revealable.top,
+            )
 
-		override fun align(size: Int, layout: Int, space: Int): Int = layout - size
-	}
+        override fun align(size: Int, layout: Int, space: Int): Int = layout - size
+    }
 
-	public data object Bottom : Vertical {
+    public data object Bottom : Vertical {
 
-		override fun arrange(revealable: IntRect, space: IntSize, confineWidth: Boolean): IntRect =
-			IntRect(
-				left = if (confineWidth) revealable.left else 0,
-				top = revealable.bottom,
-				right = if (confineWidth) revealable.right else space.width,
-				bottom = space.height,
-			)
+        override fun arrange(revealable: IntRect, space: IntSize, confineWidth: Boolean): IntRect =
+            IntRect(
+                left = if (confineWidth) revealable.left else 0,
+                top = revealable.bottom,
+                right = if (confineWidth) revealable.right else space.width,
+                bottom = space.height,
+            )
 
-		override fun align(size: Int, layout: Int, space: Int): Int = space - layout
-	}
+        override fun align(size: Int, layout: Int, space: Int): Int = space - layout
+    }
 
-	public sealed interface Horizontal {
+    public sealed interface Horizontal {
 
-		/**
-		 * Returns an [IntRect] which represents the position and size of the overlay layout area
-		 * for a [revealable] within available [space].
-		 */
-		public fun arrange(
-			revealable: IntRect,
-			space: IntSize,
-			confineHeight: Boolean,
-			layoutDirection: LayoutDirection,
-		): IntRect
+        /**
+         * Returns an [IntRect] which represents the position and size of the overlay layout area
+         * for a [revealable] within available [space].
+         */
+        public fun arrange(
+            revealable: IntRect,
+            space: IntSize,
+            confineHeight: Boolean,
+            layoutDirection: LayoutDirection,
+        ): IntRect
 
-		/**
-		 * Returns the X offset to place the overlay content with width [size] in available [layout]
-		 * width and total [space] width.
-		 */
-		public fun align(size: Int, layout: Int, space: Int): Int
-	}
+        /**
+         * Returns the X offset to place the overlay content with width [size] in available [layout]
+         * width and total [space] width.
+         */
+        public fun align(size: Int, layout: Int, space: Int): Int
+    }
 
-	public sealed interface Vertical {
+    public sealed interface Vertical {
 
-		/**
-		 * Returns an [IntRect] which represents the position and size of the overlay layout area
-		 * for a [revealable] within available [space].
-		 */
-		public fun arrange(revealable: IntRect, space: IntSize, confineWidth: Boolean): IntRect
+        /**
+         * Returns an [IntRect] which represents the position and size of the overlay layout area
+         * for a [revealable] within available [space].
+         */
+        public fun arrange(revealable: IntRect, space: IntSize, confineWidth: Boolean): IntRect
 
-		/**
-		 * Returns an Y offset to place the overlay content with height [size] in available [layout]
-		 * height and total [space] height.
-		 */
-		public fun align(size: Int, layout: Int, space: Int): Int
-	}
+        /**
+         * Returns an Y offset to place the overlay content with height [size] in available [layout]
+         * height and total [space] height.
+         */
+        public fun align(size: Int, layout: Int, space: Int): Int
+    }
 }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayScope.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayScope.kt
@@ -16,164 +16,164 @@ import androidx.compose.ui.unit.IntSize
 @Immutable
 public interface RevealOverlayScope {
 
-	/**
-	 * Aligns the element horizontally either to the start or end of the reveal area.
-	 * Additionally the element is vertically aligned in relation to the reveal area via
-	 * [verticalAlignment]. Set [confineHeight] to `false` to not confine the height to the height
-	 * of the reveal area. For instance use it with a vertical alignment of [Alignment.Top] to
-	 * implement a custom alignment.
-	 *
-	 * Should be one of the first modifiers applied to the element so that other modifiers are
-	 * applied after the element was positioned.
-	 *
-	 * @param horizontalArrangement Horizontal arrangement (start, end)
-	 * @param verticalAlignment Vertical alignment of element in relation to reveal area
-	 * @param confineHeight Confine height of element to height of reveal area
-	 *
-	 * @see RevealOverlayArrangement.Horizontal
-	 */
-	public fun Modifier.align(
-		horizontalArrangement: RevealOverlayArrangement.Horizontal,
-		verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-		confineHeight: Boolean = true,
-	): Modifier
+    /**
+     * Aligns the element horizontally either to the start or end of the reveal area.
+     * Additionally the element is vertically aligned in relation to the reveal area via
+     * [verticalAlignment]. Set [confineHeight] to `false` to not confine the height to the height
+     * of the reveal area. For instance use it with a vertical alignment of [Alignment.Top] to
+     * implement a custom alignment.
+     *
+     * Should be one of the first modifiers applied to the element so that other modifiers are
+     * applied after the element was positioned.
+     *
+     * @param horizontalArrangement Horizontal arrangement (start, end)
+     * @param verticalAlignment Vertical alignment of element in relation to reveal area
+     * @param confineHeight Confine height of element to height of reveal area
+     *
+     * @see RevealOverlayArrangement.Horizontal
+     */
+    public fun Modifier.align(
+        horizontalArrangement: RevealOverlayArrangement.Horizontal,
+        verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+        confineHeight: Boolean = true,
+    ): Modifier
 
-	/**
-	 * Aligns the element vertically either to the top or bottom of the reveal area.
-	 * Additionally the element is horizontally aligned in relation to the reveal area via
-	 * [horizontalAlignment]. Set [confineWidth] to `false` to not confine the width to the width
-	 * of the reveal area. For instance use it with a horizontal alignment of [Alignment.Start] to
-	 * implement a custom alignment.
-	 *
-	 * Should be one of the first modifiers applied to the element so that other modifiers are
-	 * applied after the element was positioned.
-	 *
-	 * @param verticalArrangement Vertical arrangement (top, bottom)
-	 * @param horizontalAlignment Horizontal alignment in relation to reveal area
-	 * @param confineWidth Confine width of element to width of reveal area
-	 *
-	 * @see RevealOverlayArrangement.Vertical
-	 */
-	public fun Modifier.align(
-		verticalArrangement: RevealOverlayArrangement.Vertical,
-		horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
-		confineWidth: Boolean = true,
-	): Modifier
+    /**
+     * Aligns the element vertically either to the top or bottom of the reveal area.
+     * Additionally the element is horizontally aligned in relation to the reveal area via
+     * [horizontalAlignment]. Set [confineWidth] to `false` to not confine the width to the width
+     * of the reveal area. For instance use it with a horizontal alignment of [Alignment.Start] to
+     * implement a custom alignment.
+     *
+     * Should be one of the first modifiers applied to the element so that other modifiers are
+     * applied after the element was positioned.
+     *
+     * @param verticalArrangement Vertical arrangement (top, bottom)
+     * @param horizontalAlignment Horizontal alignment in relation to reveal area
+     * @param confineWidth Confine width of element to width of reveal area
+     *
+     * @see RevealOverlayArrangement.Vertical
+     */
+    public fun Modifier.align(
+        verticalArrangement: RevealOverlayArrangement.Vertical,
+        horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+        confineWidth: Boolean = true,
+    ): Modifier
 }
 
 internal class RevealOverlayScopeInstance(
-	private val revealableRect: IntRect,
-	private val arrowAnchor: RevealOverlayArrowAnchor,
+    private val revealableRect: IntRect,
+    private val arrowAnchor: RevealOverlayArrowAnchor,
 ) : RevealOverlayScope {
 
-	override fun Modifier.align(
-		horizontalArrangement: RevealOverlayArrangement.Horizontal,
-		verticalAlignment: Alignment.Vertical,
-		confineHeight: Boolean,
-	): Modifier = this.then(
-		Modifier.layout { measurable, constraints ->
-			val space = IntSize(
-				width = constraints.maxWidth,
-				height = constraints.maxHeight,
-			)
-			val layoutSize = horizontalArrangement.arrange(
-				revealable = revealableRect,
-				space = space,
-				confineHeight = confineHeight,
-				layoutDirection = layoutDirection,
-			)
-			// Constrain the content to the available space so it never exceeds the
-			// boundaries of the screen. The width is confined to the arranged layout area
-			// (the space beside the reveal area), the height to the whole available space.
-			val placeable = measurable.measure(
-				constraints.copy(
-					maxWidth = layoutSize.width,
-					maxHeight = space.height,
-				),
-			)
+    override fun Modifier.align(
+        horizontalArrangement: RevealOverlayArrangement.Horizontal,
+        verticalAlignment: Alignment.Vertical,
+        confineHeight: Boolean,
+    ): Modifier = this.then(
+        Modifier.layout { measurable, constraints ->
+            val space = IntSize(
+                width = constraints.maxWidth,
+                height = constraints.maxHeight,
+            )
+            val layoutSize = horizontalArrangement.arrange(
+                revealable = revealableRect,
+                space = space,
+                confineHeight = confineHeight,
+                layoutDirection = layoutDirection,
+            )
+            // Constrain the content to the available space so it never exceeds the
+            // boundaries of the screen. The width is confined to the arranged layout area
+            // (the space beside the reveal area), the height to the whole available space.
+            val placeable = measurable.measure(
+                constraints.copy(
+                    maxWidth = layoutSize.width,
+                    maxHeight = space.height,
+                ),
+            )
 
-			layout(space.width, space.height) {
-				val x = horizontalArrangement.align(
-					size = placeable.width,
-					layout = layoutSize.width,
-					space = space.width,
-				)
-				val y = layoutSize.top +
-					verticalAlignment.align(
-						size = placeable.height,
-						space = layoutSize.height,
-					)
-				val placedX = x.coerceWithin(size = placeable.width, space = space.width)
-				val placedY = y.coerceWithin(size = placeable.height, space = space.height)
-				// The content is placed to the side of the reveal area, so the arrow points
-				// horizontally and slides along the vertical axis towards the reveal center.
-				// The offset is stored relative to the composable's outer center so that the
-				// BalloonShape can recover the correct shape-local coordinate via size/2 + offset
-				// without needing to know the caller's outer padding value.
-				arrowAnchor.offsetX = null
-				arrowAnchor.offsetY =
-					(revealableRect.center.y - placedY - placeable.height / 2).toFloat()
-				placeable.placeRelative(x = placedX, y = placedY)
-			}
-		},
-	)
+            layout(space.width, space.height) {
+                val x = horizontalArrangement.align(
+                    size = placeable.width,
+                    layout = layoutSize.width,
+                    space = space.width,
+                )
+                val y = layoutSize.top +
+                    verticalAlignment.align(
+                        size = placeable.height,
+                        space = layoutSize.height,
+                    )
+                val placedX = x.coerceWithin(size = placeable.width, space = space.width)
+                val placedY = y.coerceWithin(size = placeable.height, space = space.height)
+                // The content is placed to the side of the reveal area, so the arrow points
+                // horizontally and slides along the vertical axis towards the reveal center.
+                // The offset is stored relative to the composable's outer center so that the
+                // BalloonShape can recover the correct shape-local coordinate via size/2 + offset
+                // without needing to know the caller's outer padding value.
+                arrowAnchor.offsetX = null
+                arrowAnchor.offsetY =
+                    (revealableRect.center.y - placedY - placeable.height / 2).toFloat()
+                placeable.placeRelative(x = placedX, y = placedY)
+            }
+        },
+    )
 
-	override fun Modifier.align(
-		verticalArrangement: RevealOverlayArrangement.Vertical,
-		horizontalAlignment: Alignment.Horizontal,
-		confineWidth: Boolean,
-	): Modifier = this.then(
-		Modifier.layout { measurable, constraints ->
-			val space = IntSize(
-				width = constraints.maxWidth,
-				height = constraints.maxHeight,
-			)
-			val layoutSize = verticalArrangement.arrange(
-				revealable = revealableRect,
-				space = space,
-				confineWidth = confineWidth,
-			)
-			// Constrain the content to the available space so it never exceeds the
-			// boundaries of the screen. The height is confined to the arranged layout area
-			// (the space above/below the reveal area), the width to the whole available space.
-			val placeable = measurable.measure(
-				constraints.copy(
-					maxWidth = space.width,
-					maxHeight = layoutSize.height,
-				),
-			)
+    override fun Modifier.align(
+        verticalArrangement: RevealOverlayArrangement.Vertical,
+        horizontalAlignment: Alignment.Horizontal,
+        confineWidth: Boolean,
+    ): Modifier = this.then(
+        Modifier.layout { measurable, constraints ->
+            val space = IntSize(
+                width = constraints.maxWidth,
+                height = constraints.maxHeight,
+            )
+            val layoutSize = verticalArrangement.arrange(
+                revealable = revealableRect,
+                space = space,
+                confineWidth = confineWidth,
+            )
+            // Constrain the content to the available space so it never exceeds the
+            // boundaries of the screen. The height is confined to the arranged layout area
+            // (the space above/below the reveal area), the width to the whole available space.
+            val placeable = measurable.measure(
+                constraints.copy(
+                    maxWidth = space.width,
+                    maxHeight = layoutSize.height,
+                ),
+            )
 
-			layout(space.width, space.height) {
-				// Using place() instead of placeRelative() because layoutSize and the value
-				// returned by horizontalAlignment.align() are RTL-aware
-				val x = layoutSize.left +
-					horizontalAlignment.align(
-						size = placeable.width,
-						space = layoutSize.width,
-						layoutDirection = layoutDirection,
-					)
-				val y = verticalArrangement.align(
-					size = placeable.height,
-					layout = layoutSize.height,
-					space = space.height,
-				)
-				val placedX = x.coerceWithin(size = placeable.width, space = space.width)
-				val placedY = y.coerceWithin(size = placeable.height, space = space.height)
-				// The content is placed above/below the reveal area, so the arrow points
-				// vertically and slides along the horizontal axis towards the reveal center.
-				// The offset is stored relative to the composable's outer center so that the
-				// BalloonShape can recover the correct shape-local coordinate via size/2 + offset
-				// without needing to know the caller's outer padding value.
-				arrowAnchor.offsetX =
-					(revealableRect.center.x - placedX - placeable.width / 2).toFloat()
-				arrowAnchor.offsetY = null
-				placeable.place(
-					x = placedX,
-					y = placedY,
-				)
-			}
-		},
-	)
+            layout(space.width, space.height) {
+                // Using place() instead of placeRelative() because layoutSize and the value
+                // returned by horizontalAlignment.align() are RTL-aware
+                val x = layoutSize.left +
+                    horizontalAlignment.align(
+                        size = placeable.width,
+                        space = layoutSize.width,
+                        layoutDirection = layoutDirection,
+                    )
+                val y = verticalArrangement.align(
+                    size = placeable.height,
+                    layout = layoutSize.height,
+                    space = space.height,
+                )
+                val placedX = x.coerceWithin(size = placeable.width, space = space.width)
+                val placedY = y.coerceWithin(size = placeable.height, space = space.height)
+                // The content is placed above/below the reveal area, so the arrow points
+                // vertically and slides along the horizontal axis towards the reveal center.
+                // The offset is stored relative to the composable's outer center so that the
+                // BalloonShape can recover the correct shape-local coordinate via size/2 + offset
+                // without needing to know the caller's outer padding value.
+                arrowAnchor.offsetX =
+                    (revealableRect.center.x - placedX - placeable.width / 2).toFloat()
+                arrowAnchor.offsetY = null
+                placeable.place(
+                    x = placedX,
+                    y = placedY,
+                )
+            }
+        },
+    )
 }
 
 /**
@@ -181,4 +181,4 @@ internal class RevealOverlayScopeInstance(
  * back into bounds when it would otherwise overflow the start or end of the available space.
  */
 private fun Int.coerceWithin(size: Int, space: Int): Int =
-	coerceIn(0, (space - size).coerceAtLeast(0))
+    coerceIn(0, (space - size).coerceAtLeast(0))

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealScope.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealScope.kt
@@ -13,150 +13,150 @@ import androidx.compose.ui.unit.dp
 @Immutable
 public interface RevealScope {
 
-	/**
-	 * Registers the element as a revealable item.
-	 *
-	 * [key] must be unique in the current scope and should be used for [RevealState.reveal].
-	 * Internally [Modifier.onGloballyPositioned] is used. Hence elements are only registered after
-	 * they have been laid out.
-	 *
-	 * If the element that this modifier is applied to leaves the composition while the reveal
-	 * effect is shown for the element, the effect is finished.
-	 *
-	 * @param key          Unique key to identify the revealable content. Also see documentation of [Key].
-	 * @param shape        Shape of the reveal effect around the element. Defaults to a rounded rect
-	 *                     with a corner size of 4 dp.
-	 * @param padding      Additional padding around the reveal area. Positive values increase area
-	 *                     while negative values decrease it. Defaults to 8 dp on all sides.
-	 * @param borderStroke Optional border around the revealable item.
-	 * @param onClick      If `null` clicks will be handled by `onRevealableClick` of `Reveal`.
-	 *                     If set to `OnClick.Listener` clicks will be handled by this listener.
-	 *                     If set to `OnClick.Passthrough` Reveal will not intercept clicks and clicks
-	 *                     will be passed through to underlying composables.
-	 *
-	 * @see Key
-	 */
-	public fun Modifier.revealable(
-		key: Key,
-		shape: RevealShape = RevealShape.RoundRect(4.dp),
-		padding: PaddingValues = PaddingValues(8.dp),
-		borderStroke: BorderStroke? = null,
-		onClick: OnClick? = null,
-	): Modifier
+    /**
+     * Registers the element as a revealable item.
+     *
+     * [key] must be unique in the current scope and should be used for [RevealState.reveal].
+     * Internally [Modifier.onGloballyPositioned] is used. Hence elements are only registered after
+     * they have been laid out.
+     *
+     * If the element that this modifier is applied to leaves the composition while the reveal
+     * effect is shown for the element, the effect is finished.
+     *
+     * @param key          Unique key to identify the revealable content. Also see documentation of [Key].
+     * @param shape        Shape of the reveal effect around the element. Defaults to a rounded rect
+     *                     with a corner size of 4 dp.
+     * @param padding      Additional padding around the reveal area. Positive values increase area
+     *                     while negative values decrease it. Defaults to 8 dp on all sides.
+     * @param borderStroke Optional border around the revealable item.
+     * @param onClick      If `null` clicks will be handled by `onRevealableClick` of `Reveal`.
+     *                     If set to `OnClick.Listener` clicks will be handled by this listener.
+     *                     If set to `OnClick.Passthrough` Reveal will not intercept clicks and clicks
+     *                     will be passed through to underlying composables.
+     *
+     * @see Key
+     */
+    public fun Modifier.revealable(
+        key: Key,
+        shape: RevealShape = RevealShape.RoundRect(4.dp),
+        padding: PaddingValues = PaddingValues(8.dp),
+        borderStroke: BorderStroke? = null,
+        onClick: OnClick? = null,
+    ): Modifier
 
-	/**
-	 * Registers the element as a revealable item.
-	 *
-	 * Each key in [keys] must be unique in the current scope and should be used for
-	 * [RevealState.reveal]. Internally [Modifier.onGloballyPositioned] is used. Hence elements are
-	 * only registered after they have been laid out.
-	 *
-	 * If the element that this modifier is applied to leaves the composition while the reveal
-	 * effect is shown for the element, the effect is finished.
-	 *
-	 * @param keys         Unique keys to identify the revealable content. Also see documentation of [Key].
-	 * @param shape        Shape of the reveal effect around the element. Defaults to a rounded rect
-	 *                     with a corner size of 4 dp.
-	 * @param padding      Additional padding around the reveal area. Positive values increase area
-	 *                     while negative values decrease it. Defaults to 8 dp on all sides.
-	 * @param borderStroke Optional border around the revealable item.
-	 * @param onClick      If `null` clicks will be handled by `onRevealableClick` of `Reveal`.
-	 *                     If set to `OnClick.Listener` clicks will be handled by this listener.
-	 *                     If set to `OnClick.Passthrough` Reveal will not intercept clicks and clicks
-	 *                     will be passed through to underlying composables.
-	 *
-	 * @see Key
-	 */
-	public fun Modifier.revealable(
-		vararg keys: Key,
-		shape: RevealShape = RevealShape.RoundRect(4.dp),
-		padding: PaddingValues = PaddingValues(8.dp),
-		borderStroke: BorderStroke? = null,
-		onClick: OnClick? = null,
-	): Modifier
+    /**
+     * Registers the element as a revealable item.
+     *
+     * Each key in [keys] must be unique in the current scope and should be used for
+     * [RevealState.reveal]. Internally [Modifier.onGloballyPositioned] is used. Hence elements are
+     * only registered after they have been laid out.
+     *
+     * If the element that this modifier is applied to leaves the composition while the reveal
+     * effect is shown for the element, the effect is finished.
+     *
+     * @param keys         Unique keys to identify the revealable content. Also see documentation of [Key].
+     * @param shape        Shape of the reveal effect around the element. Defaults to a rounded rect
+     *                     with a corner size of 4 dp.
+     * @param padding      Additional padding around the reveal area. Positive values increase area
+     *                     while negative values decrease it. Defaults to 8 dp on all sides.
+     * @param borderStroke Optional border around the revealable item.
+     * @param onClick      If `null` clicks will be handled by `onRevealableClick` of `Reveal`.
+     *                     If set to `OnClick.Listener` clicks will be handled by this listener.
+     *                     If set to `OnClick.Passthrough` Reveal will not intercept clicks and clicks
+     *                     will be passed through to underlying composables.
+     *
+     * @see Key
+     */
+    public fun Modifier.revealable(
+        vararg keys: Key,
+        shape: RevealShape = RevealShape.RoundRect(4.dp),
+        padding: PaddingValues = PaddingValues(8.dp),
+        borderStroke: BorderStroke? = null,
+        onClick: OnClick? = null,
+    ): Modifier
 
-	/**
-	 * Registers the element as a revealable item.
-	 *
-	 * Each key specified in [keys] must be unique in the current scope and should be used for
-	 * [RevealState.reveal]. Internally [Modifier.onGloballyPositioned] is used. Hence elements are
-	 * only registered after they have been laid out.
-	 *
-	 * If the element that this modifier is applied to leaves the composition while the reveal
-	 * effect is shown for the element, the effect is finished.
-	 *
-	 * @param keys         Unique keys to identify the revealable content. Also see documentation of [Key].
-	 * @param shape        Shape of the reveal effect around the element. Defaults to a rounded rect
-	 *                     with a corner size of 4 dp.
-	 * @param padding      Additional padding around the reveal area. Positive values increase area
-	 *                     while negative values decrease it. Defaults to 8 dp on all sides.
-	 * @param borderStroke Optional border around the revealable item.
-	 * @param onClick      If `null` clicks will be handled by `onRevealableClick` of `Reveal`.
-	 *                     If set to `OnClick.Listener` clicks will be handled by this listener.
-	 *                     If set to `OnClick.Passthrough` Reveal will not intercept clicks and clicks
-	 *                     will be passed through to underlying composables.
-	 *
-	 * @see Key
-	 */
-	public fun Modifier.revealable(
-		keys: Iterable<Key>,
-		shape: RevealShape = RevealShape.RoundRect(4.dp),
-		padding: PaddingValues = PaddingValues(8.dp),
-		borderStroke: BorderStroke? = null,
-		onClick: OnClick? = null,
-	): Modifier
+    /**
+     * Registers the element as a revealable item.
+     *
+     * Each key specified in [keys] must be unique in the current scope and should be used for
+     * [RevealState.reveal]. Internally [Modifier.onGloballyPositioned] is used. Hence elements are
+     * only registered after they have been laid out.
+     *
+     * If the element that this modifier is applied to leaves the composition while the reveal
+     * effect is shown for the element, the effect is finished.
+     *
+     * @param keys         Unique keys to identify the revealable content. Also see documentation of [Key].
+     * @param shape        Shape of the reveal effect around the element. Defaults to a rounded rect
+     *                     with a corner size of 4 dp.
+     * @param padding      Additional padding around the reveal area. Positive values increase area
+     *                     while negative values decrease it. Defaults to 8 dp on all sides.
+     * @param borderStroke Optional border around the revealable item.
+     * @param onClick      If `null` clicks will be handled by `onRevealableClick` of `Reveal`.
+     *                     If set to `OnClick.Listener` clicks will be handled by this listener.
+     *                     If set to `OnClick.Passthrough` Reveal will not intercept clicks and clicks
+     *                     will be passed through to underlying composables.
+     *
+     * @see Key
+     */
+    public fun Modifier.revealable(
+        keys: Iterable<Key>,
+        shape: RevealShape = RevealShape.RoundRect(4.dp),
+        padding: PaddingValues = PaddingValues(8.dp),
+        borderStroke: BorderStroke? = null,
+        onClick: OnClick? = null,
+    ): Modifier
 }
 
 internal class RevealScopeInstance(private val revealState: RevealState) : RevealScope {
 
-	override fun Modifier.revealable(
-		key: Key,
-		shape: RevealShape,
-		padding: PaddingValues,
-		borderStroke: BorderStroke?,
-		onClick: OnClick?,
-	): Modifier = this.then(
-		Modifier.revealable(
-			key = key,
-			state = revealState,
-			shape = shape,
-			padding = padding,
-			borderStroke = borderStroke,
-			onClick = onClick,
-		),
-	)
+    override fun Modifier.revealable(
+        key: Key,
+        shape: RevealShape,
+        padding: PaddingValues,
+        borderStroke: BorderStroke?,
+        onClick: OnClick?,
+    ): Modifier = this.then(
+        Modifier.revealable(
+            key = key,
+            state = revealState,
+            shape = shape,
+            padding = padding,
+            borderStroke = borderStroke,
+            onClick = onClick,
+        ),
+    )
 
-	override fun Modifier.revealable(
-		vararg keys: Key,
-		shape: RevealShape,
-		padding: PaddingValues,
-		borderStroke: BorderStroke?,
-		onClick: OnClick?,
-	): Modifier = this.then(
-		Modifier.revealable(
-			keys = keys,
-			state = revealState,
-			shape = shape,
-			padding = padding,
-			borderStroke = borderStroke,
-			onClick = onClick,
-		),
-	)
+    override fun Modifier.revealable(
+        vararg keys: Key,
+        shape: RevealShape,
+        padding: PaddingValues,
+        borderStroke: BorderStroke?,
+        onClick: OnClick?,
+    ): Modifier = this.then(
+        Modifier.revealable(
+            keys = keys,
+            state = revealState,
+            shape = shape,
+            padding = padding,
+            borderStroke = borderStroke,
+            onClick = onClick,
+        ),
+    )
 
-	override fun Modifier.revealable(
-		keys: Iterable<Key>,
-		shape: RevealShape,
-		padding: PaddingValues,
-		borderStroke: BorderStroke?,
-		onClick: OnClick?,
-	): Modifier = this.then(
-		Modifier.revealable(
-			keys = keys,
-			state = revealState,
-			shape = shape,
-			padding = padding,
-			borderStroke = borderStroke,
-			onClick = onClick,
-		),
-	)
+    override fun Modifier.revealable(
+        keys: Iterable<Key>,
+        shape: RevealShape,
+        padding: PaddingValues,
+        borderStroke: BorderStroke?,
+        onClick: OnClick?,
+    ): Modifier = this.then(
+        Modifier.revealable(
+            keys = keys,
+            state = revealState,
+            shape = shape,
+            padding = padding,
+            borderStroke = borderStroke,
+            onClick = onClick,
+        ),
+    )
 }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealShape.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealShape.kt
@@ -15,57 +15,61 @@ import androidx.compose.ui.unit.LayoutDirection
  */
 public sealed interface RevealShape {
 
-	/**
-	 * Returns a [Path] which is used to clip the area around the revealable item with given [size].
-	 */
-	public fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path
+    /**
+     * Returns a [Path] which is used to clip the area around the revealable item with given [size].
+     */
+    public fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path
 
-	public data object Rect : RevealShape {
+    public data object Rect : RevealShape {
 
-		override fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path =
-			Path().apply {
-				addRect(size.asRect())
-			}
-	}
+        override fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path =
+            Path().apply {
+                addRect(size.asRect())
+            }
+    }
 
-	public data object Circle : RevealShape {
+    public data object Circle : RevealShape {
 
-		override fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path =
-			Path().apply {
-				addOval(size.asRect())
-			}
-	}
+        override fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path =
+            Path().apply {
+                addOval(size.asRect())
+            }
+    }
 
-	public class RoundRect(private val cornerSize: Dp) : RevealShape {
+    public class RoundRect(private val cornerSize: Dp) : RevealShape {
 
-		override fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path =
-			Path().apply {
-				val cornerSizePx = with(density) { cornerSize.toPx() }
-				addRoundRect(
-					RoundRect(
-						size.asRect(),
-						CornerRadius(cornerSizePx, cornerSizePx),
-					),
-				)
-			}
-	}
+        override fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path =
+            Path().apply {
+                val cornerSizePx = with(density) { cornerSize.toPx() }
+                addRoundRect(
+                    RoundRect(
+                        size.asRect(),
+                        CornerRadius(cornerSizePx, cornerSizePx),
+                    ),
+                )
+            }
+    }
 
-	/**
-	 * A custom shape.
-	 *
-	 * [onClip] should return a Path which is used to clip the area around the revealable item with
-	 * given `size`.
-	 */
-	public class Custom(
-		private val onClip: (size: Size, density: Density, layoutDirection: LayoutDirection) -> Path,
-	) : RevealShape {
+    /**
+     * A custom shape.
+     *
+     * [onClip] should return a Path which is used to clip the area around the revealable item with
+     * given `size`.
+     */
+    public class Custom(
+        private val onClip: (
+            size: Size,
+            density: Density,
+            layoutDirection: LayoutDirection,
+        ) -> Path,
+    ) : RevealShape {
 
-		override fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path =
-			onClip(size, density, layoutDirection)
-	}
+        override fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path =
+            onClip(size, density, layoutDirection)
+    }
 
-	public fun Size.asRect(): ComposeRect = ComposeRect(
-		offset = Offset.Zero,
-		size = this,
-	)
+    public fun Size.asRect(): ComposeRect = ComposeRect(
+        offset = Offset.Zero,
+        size = this,
+    )
 }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealState.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealState.kt
@@ -19,178 +19,178 @@ import kotlinx.coroutines.sync.withLock
 @Stable
 @Suppress("MemberVisibilityCanBePrivate")
 public class RevealState internal constructor(
-	visible: Boolean,
-	private val restoreCurrentRevealableKey: Key?,
+    visible: Boolean,
+    private val restoreCurrentRevealableKey: Key?,
 ) {
 
-	public constructor() : this(
-		visible = false,
-		restoreCurrentRevealableKey = null,
-	)
+    public constructor() : this(
+        visible = false,
+        restoreCurrentRevealableKey = null,
+    )
 
-	private val mutex = Mutex()
-	private var didRestoreCurrentRevealable = false
-	private var visible by mutableStateOf(visible)
-	private val revealables = mutableStateMapOf<Key, Revealable>()
-	internal var currentRevealable by mutableStateOf<Revealable?>(null)
-		private set
-	internal var previousRevealable by mutableStateOf<Revealable?>(null)
-		private set
+    private val mutex = Mutex()
+    private var didRestoreCurrentRevealable = false
+    private var visible by mutableStateOf(visible)
+    private val revealables = mutableStateMapOf<Key, Revealable>()
+    internal var currentRevealable by mutableStateOf<Revealable?>(null)
+        private set
+    internal var previousRevealable by mutableStateOf<Revealable?>(null)
+        private set
 
-	/**
-	 * Returns `true` if reveal effect is visible, else `false`
-	 */
-	public val isVisible: Boolean
-		get() = visible
+    /**
+     * Returns `true` if reveal effect is visible, else `false`
+     */
+    public val isVisible: Boolean
+        get() = visible
 
-	/**
-	 * Observable key of current revealable or `null` if no revealable is currently visible
-	 *
-	 * @see previousRevealableKey
-	 */
-	public val currentRevealableKey: Key?
-		get() = currentRevealable?.key
+    /**
+     * Observable key of current revealable or `null` if no revealable is currently visible
+     *
+     * @see previousRevealableKey
+     */
+    public val currentRevealableKey: Key?
+        get() = currentRevealable?.key
 
-	/**
-	 * Observable key of previous revealable which was displayed before [currentRevealableKey]
-	 *
-	 * @see currentRevealableKey
-	 */
-	public val previousRevealableKey: Key?
-		get() = previousRevealable?.key
+    /**
+     * Observable key of previous revealable which was displayed before [currentRevealableKey]
+     *
+     * @see currentRevealableKey
+     */
+    public val previousRevealableKey: Key?
+        get() = previousRevealable?.key
 
-	/**
-	 * Observable set of keys known to this state instance
-	 *
-	 * Can be used to query when a revealable was registered via [RevealScope.revealable].
-	 */
-	public val revealableKeys: Set<Key>
-		get() = revealables.keys
+    /**
+     * Observable set of keys known to this state instance
+     *
+     * Can be used to query when a revealable was registered via [RevealScope.revealable].
+     */
+    public val revealableKeys: Set<Key>
+        get() = revealables.keys
 
-	/**
-	 * Reveals revealable with given [key]
-	 *
-	 * Might throw [IllegalArgumentException] if the revealable item is not known to Reveal. This
-	 * might happen if for example the item is in a lazy container and is currently not part of the
-	 * visible area. It is the duty of the developer to ensure that a revealable item is currently
-	 * visible (known to Reveal) before calling this function. Additionally [containsRevealable] or
-	 * [revealableKeys] can be used to ensure this.
-	 *
-	 * @see tryReveal
-	 * @see containsRevealable
-	 * @see revealableKeys
-	 * @throws IllegalArgumentException if revealable with given key was not found
-	 */
-	public suspend fun reveal(key: Key) {
-		require(containsRevealable(key)) { "Revealable with key \"$key\" not found" }
-		internalReveal(key)
-	}
+    /**
+     * Reveals revealable with given [key]
+     *
+     * Might throw [IllegalArgumentException] if the revealable item is not known to Reveal. This
+     * might happen if for example the item is in a lazy container and is currently not part of the
+     * visible area. It is the duty of the developer to ensure that a revealable item is currently
+     * visible (known to Reveal) before calling this function. Additionally [containsRevealable] or
+     * [revealableKeys] can be used to ensure this.
+     *
+     * @see tryReveal
+     * @see containsRevealable
+     * @see revealableKeys
+     * @throws IllegalArgumentException if revealable with given key was not found
+     */
+    public suspend fun reveal(key: Key) {
+        require(containsRevealable(key)) { "Revealable with key \"$key\" not found" }
+        internalReveal(key)
+    }
 
-	/**
-	 * Like [reveal] but doesn't throw exception if revealable was not found.
-	 * Instead returns `false`.
-	 *
-	 * @see reveal
-	 */
-	public suspend fun tryReveal(key: Key): Boolean {
-		if (!containsRevealable(key)) return false
-		internalReveal(key)
-		return true
-	}
+    /**
+     * Like [reveal] but doesn't throw exception if revealable was not found.
+     * Instead returns `false`.
+     *
+     * @see reveal
+     */
+    public suspend fun tryReveal(key: Key): Boolean {
+        if (!containsRevealable(key)) return false
+        internalReveal(key)
+        return true
+    }
 
-	private suspend fun internalReveal(key: Key) {
-		mutex.withLock {
-			previousRevealable = currentRevealable
-			currentRevealable = revealables[key]
-			visible = true
-		}
-	}
+    private suspend fun internalReveal(key: Key) {
+        mutex.withLock {
+            previousRevealable = currentRevealable
+            currentRevealable = revealables[key]
+            visible = true
+        }
+    }
 
-	/**
-	 * Hides reveal effect
-	 */
-	public suspend fun hide() {
-		mutex.withLock {
-			visible = false
-		}
-	}
+    /**
+     * Hides reveal effect
+     */
+    public suspend fun hide() {
+        mutex.withLock {
+            visible = false
+        }
+    }
 
-	/**
-	 * Returns `true` if this state instance contains revealable with given [key]
-	 */
-	public fun containsRevealable(key: Key): Boolean = revealableKeys.contains(key)
+    /**
+     * Returns `true` if this state instance contains revealable with given [key]
+     */
+    public fun containsRevealable(key: Key): Boolean = revealableKeys.contains(key)
 
-	internal fun onHideAnimationFinished() {
-		currentRevealable = null
-		previousRevealable = null
-	}
+    internal fun onHideAnimationFinished() {
+        currentRevealable = null
+        previousRevealable = null
+    }
 
-	/**
-	 * Adds a [Revealable] to this state.
-	 *
-	 * Usually this should not be called manually but revealables registered via the
-	 * [RevealScope.revealable] modifier. Only use this function when for instance you want to
-	 * reveal legacy Android views.
-	 *
-	 * @see RevealScope.revealable
-	 */
-	public fun addRevealable(revealable: Revealable) {
-		revealables[revealable.key] = revealable
+    /**
+     * Adds a [Revealable] to this state.
+     *
+     * Usually this should not be called manually but revealables registered via the
+     * [RevealScope.revealable] modifier. Only use this function when for instance you want to
+     * reveal legacy Android views.
+     *
+     * @see RevealScope.revealable
+     */
+    public fun addRevealable(revealable: Revealable) {
+        revealables[revealable.key] = revealable
 
-		if (!didRestoreCurrentRevealable && restoreCurrentRevealableKey == revealable.key) {
-			currentRevealable = revealable
-			didRestoreCurrentRevealable = true
-		}
-	}
+        if (!didRestoreCurrentRevealable && restoreCurrentRevealableKey == revealable.key) {
+            currentRevealable = revealable
+            didRestoreCurrentRevealable = true
+        }
+    }
 
-	/**
-	 * @see addRevealable
-	 */
-	@Deprecated(
-		message = "Use addRevealable()",
-		replaceWith = ReplaceWith("addRevealable(revealable)"),
-	)
-	public fun putRevealable(revealable: Revealable): Unit = addRevealable(revealable)
+    /**
+     * @see addRevealable
+     */
+    @Deprecated(
+        message = "Use addRevealable()",
+        replaceWith = ReplaceWith("addRevealable(revealable)"),
+    )
+    public fun putRevealable(revealable: Revealable): Unit = addRevealable(revealable)
 
-	/**
-	 * Removes a [Revealable] from this state.
-	 *
-	 * Usually this should not be called manually. The [RevealScope.revealable] modifier takes care
-	 * of removing revealables when the composable is disposed.
-	 */
-	public fun removeRevealable(key: Key) {
-		revealables.remove(key)
+    /**
+     * Removes a [Revealable] from this state.
+     *
+     * Usually this should not be called manually. The [RevealScope.revealable] modifier takes care
+     * of removing revealables when the composable is disposed.
+     */
+    public fun removeRevealable(key: Key) {
+        revealables.remove(key)
 
-		// Hide effect if the current revealable left the composition.
-		// currentRevealable and previousRevealable are reset via onHideAnimationFinished().
-		if (currentRevealableKey == key) {
-			visible = false
-		}
+        // Hide effect if the current revealable left the composition.
+        // currentRevealable and previousRevealable are reset via onHideAnimationFinished().
+        if (currentRevealableKey == key) {
+            visible = false
+        }
 
-		if (previousRevealableKey == key) {
-			previousRevealable = null
-		}
-	}
+        if (previousRevealableKey == key) {
+            previousRevealable = null
+        }
+    }
 
-	internal companion object {
+    internal companion object {
 
-		internal fun newSaver(keySaver: Saver<Key, Any>): Saver<RevealState, *> = listSaver(
-			save = {
-				listOf(
-					it.isVisible,
-					it.currentRevealableKey?.let { key -> with(keySaver) { save(key) } },
-				)
-			},
-			restore = {
-				RevealState(
-					visible = it[0] as Boolean,
-					restoreCurrentRevealableKey = it[1]?.let { keySaveable ->
-						keySaver.restore(keySaveable)
-					},
-				)
-			},
-		)
-	}
+        internal fun newSaver(keySaver: Saver<Key, Any>): Saver<RevealState, *> = listSaver(
+            save = {
+                listOf(
+                    it.isVisible,
+                    it.currentRevealableKey?.let { key -> with(keySaver) { save(key) } },
+                )
+            },
+            restore = {
+                RevealState(
+                    visible = it[0] as Boolean,
+                    restoreCurrentRevealableKey = it[1]?.let { keySaveable ->
+                        keySaver.restore(keySaveable)
+                    },
+                )
+            },
+        )
+    }
 }
 
 /**
@@ -203,4 +203,4 @@ public class RevealState internal constructor(
  */
 @Composable
 public fun rememberRevealState(keySaver: Saver<Key, Any> = autoSaver()): RevealState =
-	rememberSaveable(saver = RevealState.newSaver(keySaver)) { RevealState() }
+    rememberSaveable(saver = RevealState.newSaver(keySaver)) { RevealState() }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Revealable.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Revealable.kt
@@ -12,60 +12,60 @@ import androidx.compose.ui.unit.LayoutDirection
 
 @Immutable
 public data class Revealable(
-	val key: Key,
-	val shape: RevealShape,
-	val padding: PaddingValues,
-	val borderStroke: BorderStroke?,
-	val layout: Layout,
-	val onClick: OnClick?,
+    val key: Key,
+    val shape: RevealShape,
+    val padding: PaddingValues,
+    val borderStroke: BorderStroke?,
+    val layout: Layout,
+    val onClick: OnClick?,
 ) {
 
-	/**
-	 * @param offset Offset in pixels of revealable to root composable
-	 * @param size Size in pixels of revealable
-	 */
-	@Immutable
-	public data class Layout(val offset: Offset, val size: Size)
+    /**
+     * @param offset Offset in pixels of revealable to root composable
+     * @param size Size in pixels of revealable
+     */
+    @Immutable
+    public data class Layout(val offset: Offset, val size: Size)
 }
 
 @Immutable
 public data class ActualRevealable(
-	val key: Key,
-	val shape: RevealShape,
-	val padding: PaddingValues,
-	val borderStroke: BorderStroke?,
-	val area: Rect,
-	val onClick: OnClick?,
+    val key: Key,
+    val shape: RevealShape,
+    val padding: PaddingValues,
+    val borderStroke: BorderStroke?,
+    val area: Rect,
+    val onClick: OnClick?,
 )
 
 /**
  * Returns [Rect] in pixels of the reveal area including padding for this [Revealable].
  */
 internal fun Revealable.computeArea(
-	density: Density,
-	layoutDirection: LayoutDirection,
-	additionalOffset: DpOffset,
+    density: Density,
+    layoutDirection: LayoutDirection,
+    additionalOffset: DpOffset,
 ): Rect = with(density) {
-	val rect = Rect(
-		left = layout.offset.x +
-			additionalOffset.x.toPx() -
-			padding.calculateLeftPadding(layoutDirection).toPx(),
-		top = layout.offset.y +
-			additionalOffset.y.toPx() -
-			padding.calculateTopPadding().toPx(),
-		right = layout.offset.x +
-			additionalOffset.x.toPx() +
-			padding.calculateRightPadding(layoutDirection).toPx() +
-			layout.size.width,
-		bottom = layout.offset.y +
-			additionalOffset.y.toPx() +
-			padding.calculateBottomPadding().toPx() +
-			layout.size.height,
-	)
+    val rect = Rect(
+        left = layout.offset.x +
+            additionalOffset.x.toPx() -
+            padding.calculateLeftPadding(layoutDirection).toPx(),
+        top = layout.offset.y +
+            additionalOffset.y.toPx() -
+            padding.calculateTopPadding().toPx(),
+        right = layout.offset.x +
+            additionalOffset.x.toPx() +
+            padding.calculateRightPadding(layoutDirection).toPx() +
+            layout.size.width,
+        bottom = layout.offset.y +
+            additionalOffset.y.toPx() +
+            padding.calculateBottomPadding().toPx() +
+            layout.size.height,
+    )
 
-	if (shape == RevealShape.Circle) {
-		Rect(rect.center, rect.maxDimension / 2.0f)
-	} else {
-		rect
-	}
+    if (shape == RevealShape.Circle) {
+        Rect(rect.center, rect.maxDimension / 2.0f)
+    } else {
+        rect
+    }
 }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/effect/RevealOverlayEffect.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/effect/RevealOverlayEffect.kt
@@ -14,17 +14,17 @@ import com.svenjacobs.reveal.RevealState
  */
 public interface RevealOverlayEffect {
 
-	@Composable
-	public fun Overlay(
-		revealState: RevealState,
-		currentRevealable: State<ActualRevealable?>,
-		previousRevealable: State<ActualRevealable?>,
-		modifier: Modifier,
-		content: @Composable RevealOverlayScope.(key: Key) -> Unit,
-	)
+    @Composable
+    public fun Overlay(
+        revealState: RevealState,
+        currentRevealable: State<ActualRevealable?>,
+        previousRevealable: State<ActualRevealable?>,
+        modifier: Modifier,
+        content: @Composable RevealOverlayScope.(key: Key) -> Unit,
+    )
 
-	/**
-	 * Animation spec for the animated alpha of the overlay when this effect is shown or hidden.
-	 */
-	public val alphaAnimationSpec: AnimationSpec<Float>
+    /**
+     * Animation spec for the animated alpha of the overlay when this effect is shown or hidden.
+     */
+    public val alphaAnimationSpec: AnimationSpec<Float>
 }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.key
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.movableContentWithReceiverOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -51,137 +53,140 @@ import com.svenjacobs.reveal.internal.rect.toIntRect
  */
 @Immutable
 public class DimRevealOverlayEffect(
-	override val alphaAnimationSpec: AnimationSpec<Float> = tween(durationMillis = 500),
-	private val color: Color = Color.Black.copy(alpha = 0.8f),
-	private val contentAlphaAnimationSpec: AnimationSpec<Float> = tween(durationMillis = 500),
+    override val alphaAnimationSpec: AnimationSpec<Float> = tween(durationMillis = 500),
+    private val color: Color = Color.Black.copy(alpha = 0.8f),
+    private val contentAlphaAnimationSpec: AnimationSpec<Float> = tween(durationMillis = 500),
 ) : RevealOverlayEffect {
 
-	@Composable
-	override fun Overlay(
-		revealState: RevealState,
-		currentRevealable: State<ActualRevealable?>,
-		previousRevealable: State<ActualRevealable?>,
-		modifier: Modifier,
-		content: @Composable RevealOverlayScope.(key: Key) -> Unit,
-	) {
-		val currentItemHolder = currentRevealable.value?.let {
-			rememberDimItemHolder(
-				revealable = it,
-				fromState = Gone,
-				toState = Visible,
-				contentAlphaAnimationSpec = contentAlphaAnimationSpec,
-			)
-		}
+    @Composable
+    override fun Overlay(
+        revealState: RevealState,
+        currentRevealable: State<ActualRevealable?>,
+        previousRevealable: State<ActualRevealable?>,
+        modifier: Modifier,
+        content: @Composable RevealOverlayScope.(key: Key) -> Unit,
+    ) {
+        val currentItemHolder = currentRevealable.value?.let {
+            rememberDimItemHolder(
+                revealable = it,
+                fromState = Gone,
+                toState = Visible,
+                contentAlphaAnimationSpec = contentAlphaAnimationSpec,
+            )
+        }
 
-		val prevItemHolder = previousRevealable.value?.let {
-			rememberDimItemHolder(
-				revealable = it,
-				fromState = Visible,
-				toState = Gone,
-				contentAlphaAnimationSpec = contentAlphaAnimationSpec,
-			)
-		}
+        val prevItemHolder = previousRevealable.value?.let {
+            rememberDimItemHolder(
+                revealable = it,
+                fromState = Visible,
+                toState = Gone,
+                contentAlphaAnimationSpec = contentAlphaAnimationSpec,
+            )
+        }
 
-		val density = LocalDensity.current
+        val density = LocalDensity.current
+        val movableContent = movableContentWithReceiverOf<RevealOverlayScope, Key> { key ->
+            content(key)
+        }
 
-		Box(
-			modifier = modifier
-				.graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
-				.drawBehind {
-					drawRect(color)
-					prevItemHolder?.let { with(it) { draw(density) } }
-					currentItemHolder?.let { with(it) { draw(density) } }
-				},
-		) {
-			prevItemHolder?.let { with(it) { Container(content = content) } }
-			currentItemHolder?.let { with(it) { Container(content = content) } }
-		}
-	}
+        Box(
+            modifier = modifier
+                .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+                .drawBehind {
+                    drawRect(color)
+                    prevItemHolder?.let { with(it) { draw(density) } }
+                    currentItemHolder?.let { with(it) { draw(density) } }
+                },
+        ) {
+            prevItemHolder?.let { with(it) { Container(content = movableContent) } }
+            currentItemHolder?.let { with(it) { Container(content = movableContent) } }
+        }
+    }
 }
 
 @Stable
 private class DimItemHolder(val revealable: ActualRevealable, val contentAlpha: State<Float>) {
 
-	@Composable
-	fun BoxScope.Container(
-		modifier: Modifier = Modifier,
-		content: @Composable RevealOverlayScope.(key: Key) -> Unit,
-	) {
-		// Optimization: don't place element into composition if it isn't visible at all
-		if (contentAlpha.value == 0.0f) return
+    @Composable
+    fun BoxScope.Container(
+        modifier: Modifier = Modifier,
+        content: @Composable RevealOverlayScope.(key: Key) -> Unit,
+    ) {
+        // Optimization: don't place element into composition if it isn't visible at all
+        if (contentAlpha.value == 0.0f) return
 
-		val arrowAnchor = remember { RevealOverlayArrowAnchor() }
+        val arrowAnchor = remember { RevealOverlayArrowAnchor() }
 
-		Box(
-			modifier = modifier
-				.matchParentSize()
-				.alpha(contentAlpha.value),
-			content = {
-				CompositionLocalProvider(
-					LocalRevealOverlayArrowAnchor provides arrowAnchor,
-				) {
-					RevealOverlayScopeInstance(
-						revealableRect = revealable.area.toIntRect(),
-						arrowAnchor = arrowAnchor,
-					).content(revealable.key)
-				}
-			},
-		)
-	}
+        Box(
+            modifier = modifier
+                .matchParentSize()
+                .alpha(contentAlpha.value),
+            content = {
+                CompositionLocalProvider(
+                    LocalRevealOverlayArrowAnchor provides arrowAnchor,
+                ) {
+                    RevealOverlayScopeInstance(
+                        revealableRect = revealable.area.toIntRect(),
+                        arrowAnchor = arrowAnchor,
+                    ).content(revealable.key)
+                }
+            },
+        )
+    }
 
-	fun DrawScope.draw(density: Density) {
-		val path = revealable.createShapePath(
-			density = density,
-			layoutDirection = layoutDirection,
-		)
+    fun DrawScope.draw(density: Density) {
+        val path = revealable.createShapePath(
+            density = density,
+            layoutDirection = layoutDirection,
+        )
 
-		drawCutout(path)
-		revealable.borderStroke?.let { drawBorder(path, density, it) }
-	}
+        drawCutout(path)
+        revealable.borderStroke?.let { drawBorder(path, density, it) }
+    }
 
-	private fun DrawScope.drawCutout(path: Path) {
-		drawPath(
-			path = path,
-			color = Color.Black,
-			alpha = contentAlpha.value,
-			blendMode = BlendMode.DstOut,
-		)
-	}
+    private fun DrawScope.drawCutout(path: Path) {
+        drawPath(
+            path = path,
+            color = Color.Black,
+            alpha = contentAlpha.value,
+            blendMode = BlendMode.DstOut,
+        )
+    }
 
-	private fun DrawScope.drawBorder(path: Path, density: Density, borderStroke: BorderStroke) {
-		drawPath(
-			path = path,
-			brush = borderStroke.brush,
-			style = Stroke(width = with(density) { borderStroke.width.toPx() }),
-			alpha = contentAlpha.value,
-		)
-	}
+    private fun DrawScope.drawBorder(path: Path, density: Density, borderStroke: BorderStroke) {
+        drawPath(
+            path = path,
+            brush = borderStroke.brush,
+            style = Stroke(width = with(density) { borderStroke.width.toPx() }),
+            alpha = contentAlpha.value,
+        )
+    }
 }
 
 private enum class DimItemState { Visible, Gone }
 
 @Composable
 private fun rememberDimItemHolder(
-	revealable: ActualRevealable,
-	fromState: DimItemState,
-	toState: DimItemState,
-	contentAlphaAnimationSpec: AnimationSpec<Float>,
+    revealable: ActualRevealable,
+    fromState: DimItemState,
+    toState: DimItemState,
+    contentAlphaAnimationSpec: AnimationSpec<Float>,
 ): DimItemHolder = key(revealable.key) {
-	val targetState = remember { mutableStateOf(fromState) }
-	val contentAlpha = animateFloatAsState(
-		targetValue = if (targetState.value == Visible) 1.0f else 0.0f,
-		animationSpec = contentAlphaAnimationSpec,
-		label = "contentAlpha",
-	)
+    val targetState = remember { mutableStateOf(fromState) }
+    val contentAlpha = animateFloatAsState(
+        targetValue = if (targetState.value == Visible) 1.0f else 0.0f,
+        animationSpec = contentAlphaAnimationSpec,
+        label = "contentAlpha",
+    )
 
-	LaunchedEffect(Unit) {
-		targetState.value = toState
-	}
+    LaunchedEffect(Unit) {
+        targetState.value = toState
+    }
 
-	remember {
-		DimItemHolder(
-			revealable = revealable,
-			contentAlpha = contentAlpha,
-		)
-	}
+    remember {
+        DimItemHolder(
+            revealable = revealable,
+            contentAlpha = contentAlpha,
+        )
+    }
 }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/effect/internal/Graphics.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/effect/internal/Graphics.kt
@@ -8,22 +8,22 @@ import androidx.compose.ui.unit.LayoutDirection
 import com.svenjacobs.reveal.ActualRevealable
 
 internal fun ActualRevealable.createShapePath(
-	density: Density,
-	layoutDirection: LayoutDirection,
+    density: Density,
+    layoutDirection: LayoutDirection,
 ): Path = shape
-	.clip(
-		size = Size(
-			width = area.width,
-			height = area.height,
-		),
-		density = density,
-		layoutDirection = layoutDirection,
-	)
-	.apply {
-		translate(
-			Offset(
-				x = area.left,
-				y = area.top,
-			),
-		)
-	}
+    .clip(
+        size = Size(
+            width = area.width,
+            height = area.height,
+        ),
+        density = density,
+        layoutDirection = layoutDirection,
+    )
+    .apply {
+        translate(
+            Offset(
+                x = area.left,
+                y = area.top,
+            ),
+        )
+    }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/internal/rect/Extensions.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/internal/rect/Extensions.kt
@@ -4,8 +4,8 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.unit.IntRect
 
 internal fun Rect.toIntRect(): IntRect = IntRect(
-	left = left.toInt(),
-	top = top.toInt(),
-	right = right.toInt(),
-	bottom = bottom.toInt(),
+    left = left.toInt(),
+    top = top.toInt(),
+    right = right.toInt(),
+    bottom = bottom.toInt(),
 )

--- a/reveal-shapes/build.gradle.kts
+++ b/reveal-shapes/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-	alias(libs.plugins.android.multiplatform.library)
-	id("convention.multiplatform")
-	id("convention.publication")
+    alias(libs.plugins.android.multiplatform.library)
+    id("convention.multiplatform")
+    id("convention.publication")
 }
 
 val baseName by extra { "reveal-shapes" }
@@ -11,30 +11,30 @@ val androidMinSdk: Int by rootProject.extra
 val androidCompileSdk: Int by rootProject.extra
 
 kotlin {
-	android {
-		namespace = "com.svenjacobs.reveal.shapes"
-		compileSdk { version = release(androidCompileSdk) }
-		minSdk { version = release(androidMinSdk) }
+    android {
+        namespace = "com.svenjacobs.reveal.shapes"
+        compileSdk { version = release(androidCompileSdk) }
+        minSdk { version = release(androidMinSdk) }
 
-		aarMetadata {
-			minCompileSdk = androidMinSdk
-		}
+        aarMetadata {
+            minCompileSdk = androidMinSdk
+        }
 
-		withHostTest {}
-	}
+        withHostTest {}
+    }
 
-	sourceSets {
-		commonMain.dependencies {
-			implementation(project(":reveal-common"))
-			implementation(libs.compose.multiplatform.runtime)
-			implementation(libs.compose.multiplatform.foundation)
-		}
-		commonTest.dependencies {
-			implementation(kotlin("test"))
-		}
-	}
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":reveal-common"))
+            implementation(libs.compose.multiplatform.runtime)
+            implementation(libs.compose.multiplatform.foundation)
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+    }
 }
 
 dependencies {
-	lintChecks(libs.slack.compose.lint.checks)
+    lintChecks(libs.slack.compose.lint.checks)
 }

--- a/reveal-shapes/src/commonMain/kotlin/com/svenjacobs/reveal/shapes/balloon/Arrow.kt
+++ b/reveal-shapes/src/commonMain/kotlin/com/svenjacobs/reveal/shapes/balloon/Arrow.kt
@@ -2,6 +2,7 @@ package com.svenjacobs.reveal.shapes.balloon
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
@@ -26,396 +27,399 @@ import com.svenjacobs.reveal.shapes.balloon.Arrow.Companion.top
  * @see [bottom]
  * @see Balloon
  */
+@Immutable
 public sealed interface Arrow {
 
-	public companion object {
+    public companion object {
 
-		private val DefaultHorizontalWidth = 8.dp
-		private val DefaultHorizontalHeight = 12.dp
+        private val DefaultHorizontalWidth = 8.dp
+        private val DefaultHorizontalHeight = 12.dp
 
-		/**
-		 * Default minimum distance the arrow keeps from a rounded corner when [anchorToReveal] is
-		 * enabled.
-		 */
-		public val DefaultCornerMargin: Dp = 4.dp
+        /**
+         * Default minimum distance the arrow keeps from a rounded corner when [anchorToReveal] is
+         * enabled.
+         */
+        public val DefaultCornerMargin: Dp = 4.dp
 
-		/**
-		 * Arrow pointing to the start (left in LTR, right in RTL), placed on the left side of the
-		 * balloon.
-		 *
-		 * @param width Horizontal extent of the arrow triangle.
-		 * @param height Vertical extent of the arrow triangle.
-		 * @param verticalAlignment Vertical position of the arrow when [anchorToReveal] is `false`.
-		 * @param anchorToReveal When `true` the arrow slides along the vertical axis so that it
-		 *   points towards the center of the reveal area, clamped by [cornerMargin].
-		 * @param cornerMargin Minimum distance the arrow keeps from a rounded corner when
-		 *   [anchorToReveal] is `true`. Defaults to [DefaultCornerMargin].
-		 */
-		@Composable
-		@ReadOnlyComposable
-		public fun start(
-			width: Dp = DefaultHorizontalWidth,
-			height: Dp = DefaultHorizontalHeight,
-			verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-			anchorToReveal: Boolean = false,
-			cornerMargin: Dp = DefaultCornerMargin,
-		): Arrow = when (LocalLayoutDirection.current) {
-			LayoutDirection.Ltr -> ::StartInternal
-			LayoutDirection.Rtl -> ::EndInternal
-		}(width, height, verticalAlignment, anchorToReveal, cornerMargin)
+        /**
+         * Arrow pointing to the start (left in LTR, right in RTL), placed on the left side of the
+         * balloon.
+         *
+         * @param width Horizontal extent of the arrow triangle.
+         * @param height Vertical extent of the arrow triangle.
+         * @param verticalAlignment Vertical position of the arrow when [anchorToReveal] is `false`.
+         * @param anchorToReveal When `true` the arrow slides along the vertical axis so that it
+         *   points towards the center of the reveal area, clamped by [cornerMargin].
+         * @param cornerMargin Minimum distance the arrow keeps from a rounded corner when
+         *   [anchorToReveal] is `true`. Defaults to [DefaultCornerMargin].
+         */
+        @Composable
+        @ReadOnlyComposable
+        public fun start(
+            width: Dp = DefaultHorizontalWidth,
+            height: Dp = DefaultHorizontalHeight,
+            verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+            anchorToReveal: Boolean = false,
+            cornerMargin: Dp = DefaultCornerMargin,
+        ): Arrow = when (LocalLayoutDirection.current) {
+            LayoutDirection.Ltr -> ::StartInternal
+            LayoutDirection.Rtl -> ::EndInternal
+        }(width, height, verticalAlignment, anchorToReveal, cornerMargin)
 
-		/**
-		 * Arrow pointing upward, placed on the top side of the balloon.
-		 *
-		 * @param width Horizontal extent of the arrow triangle.
-		 * @param height Vertical extent of the arrow triangle.
-		 * @param horizontalAlignment Horizontal position of the arrow when [anchorToReveal] is `false`.
-		 * @param anchorToReveal When `true` the arrow slides along the horizontal axis so that it
-		 *   points towards the center of the reveal area, clamped by [cornerMargin].
-		 * @param cornerMargin Minimum distance the arrow keeps from a rounded corner when
-		 *   [anchorToReveal] is `true`. Defaults to [DefaultCornerMargin].
-		 */
-		@Composable
-		@ReadOnlyComposable
-		public fun top(
-			width: Dp = DefaultHorizontalHeight,
-			height: Dp = DefaultHorizontalWidth,
-			horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
-			anchorToReveal: Boolean = false,
-			cornerMargin: Dp = DefaultCornerMargin,
-		): Arrow = TopInternal(
-			width = width,
-			height = height,
-			horizontalAlignment = horizontalAlignment,
-			anchorToReveal = anchorToReveal,
-			cornerMargin = cornerMargin,
-		)
+        /**
+         * Arrow pointing upward, placed on the top side of the balloon.
+         *
+         * @param width Horizontal extent of the arrow triangle.
+         * @param height Vertical extent of the arrow triangle.
+         * @param horizontalAlignment Horizontal position of the arrow when [anchorToReveal] is `false`.
+         * @param anchorToReveal When `true` the arrow slides along the horizontal axis so that it
+         *   points towards the center of the reveal area, clamped by [cornerMargin].
+         * @param cornerMargin Minimum distance the arrow keeps from a rounded corner when
+         *   [anchorToReveal] is `true`. Defaults to [DefaultCornerMargin].
+         */
+        @Composable
+        @ReadOnlyComposable
+        public fun top(
+            width: Dp = DefaultHorizontalHeight,
+            height: Dp = DefaultHorizontalWidth,
+            horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+            anchorToReveal: Boolean = false,
+            cornerMargin: Dp = DefaultCornerMargin,
+        ): Arrow = TopInternal(
+            width = width,
+            height = height,
+            horizontalAlignment = horizontalAlignment,
+            anchorToReveal = anchorToReveal,
+            cornerMargin = cornerMargin,
+        )
 
-		/**
-		 * Arrow pointing to the end (right in LTR, left in RTL), placed on the right side of the
-		 * balloon.
-		 *
-		 * @param width Horizontal extent of the arrow triangle.
-		 * @param height Vertical extent of the arrow triangle.
-		 * @param verticalAlignment Vertical position of the arrow when [anchorToReveal] is `false`.
-		 * @param anchorToReveal When `true` the arrow slides along the vertical axis so that it
-		 *   points towards the center of the reveal area, clamped by [cornerMargin].
-		 * @param cornerMargin Minimum distance the arrow keeps from a rounded corner when
-		 *   [anchorToReveal] is `true`. Defaults to [DefaultCornerMargin].
-		 */
-		@Composable
-		@ReadOnlyComposable
-		public fun end(
-			width: Dp = DefaultHorizontalWidth,
-			height: Dp = DefaultHorizontalHeight,
-			verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-			anchorToReveal: Boolean = false,
-			cornerMargin: Dp = DefaultCornerMargin,
-		): Arrow = when (LocalLayoutDirection.current) {
-			LayoutDirection.Ltr -> ::EndInternal
-			LayoutDirection.Rtl -> ::StartInternal
-		}(width, height, verticalAlignment, anchorToReveal, cornerMargin)
+        /**
+         * Arrow pointing to the end (right in LTR, left in RTL), placed on the right side of the
+         * balloon.
+         *
+         * @param width Horizontal extent of the arrow triangle.
+         * @param height Vertical extent of the arrow triangle.
+         * @param verticalAlignment Vertical position of the arrow when [anchorToReveal] is `false`.
+         * @param anchorToReveal When `true` the arrow slides along the vertical axis so that it
+         *   points towards the center of the reveal area, clamped by [cornerMargin].
+         * @param cornerMargin Minimum distance the arrow keeps from a rounded corner when
+         *   [anchorToReveal] is `true`. Defaults to [DefaultCornerMargin].
+         */
+        @Composable
+        @ReadOnlyComposable
+        public fun end(
+            width: Dp = DefaultHorizontalWidth,
+            height: Dp = DefaultHorizontalHeight,
+            verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+            anchorToReveal: Boolean = false,
+            cornerMargin: Dp = DefaultCornerMargin,
+        ): Arrow = when (LocalLayoutDirection.current) {
+            LayoutDirection.Ltr -> ::EndInternal
+            LayoutDirection.Rtl -> ::StartInternal
+        }(width, height, verticalAlignment, anchorToReveal, cornerMargin)
 
-		/**
-		 * Arrow pointing downward, placed on the bottom side of the balloon.
-		 *
-		 * @param width Horizontal extent of the arrow triangle.
-		 * @param height Vertical extent of the arrow triangle.
-		 * @param horizontalAlignment Horizontal position of the arrow when [anchorToReveal] is `false`.
-		 * @param anchorToReveal When `true` the arrow slides along the horizontal axis so that it
-		 *   points towards the center of the reveal area, clamped by [cornerMargin].
-		 * @param cornerMargin Minimum distance the arrow keeps from a rounded corner when
-		 *   [anchorToReveal] is `true`. Defaults to [DefaultCornerMargin].
-		 */
-		@Composable
-		@ReadOnlyComposable
-		public fun bottom(
-			width: Dp = DefaultHorizontalHeight,
-			height: Dp = DefaultHorizontalWidth,
-			horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
-			anchorToReveal: Boolean = false,
-			cornerMargin: Dp = DefaultCornerMargin,
-		): Arrow = BottomInternal(
-			width = width,
-			height = height,
-			horizontalAlignment = horizontalAlignment,
-			anchorToReveal = anchorToReveal,
-			cornerMargin = cornerMargin,
-		)
+        /**
+         * Arrow pointing downward, placed on the bottom side of the balloon.
+         *
+         * @param width Horizontal extent of the arrow triangle.
+         * @param height Vertical extent of the arrow triangle.
+         * @param horizontalAlignment Horizontal position of the arrow when [anchorToReveal] is `false`.
+         * @param anchorToReveal When `true` the arrow slides along the horizontal axis so that it
+         *   points towards the center of the reveal area, clamped by [cornerMargin].
+         * @param cornerMargin Minimum distance the arrow keeps from a rounded corner when
+         *   [anchorToReveal] is `true`. Defaults to [DefaultCornerMargin].
+         */
+        @Composable
+        @ReadOnlyComposable
+        public fun bottom(
+            width: Dp = DefaultHorizontalHeight,
+            height: Dp = DefaultHorizontalWidth,
+            horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+            anchorToReveal: Boolean = false,
+            cornerMargin: Dp = DefaultCornerMargin,
+        ): Arrow = BottomInternal(
+            width = width,
+            height = height,
+            horizontalAlignment = horizontalAlignment,
+            anchorToReveal = anchorToReveal,
+            cornerMargin = cornerMargin,
+        )
 
-		/**
-		 * Clamps the desired [center] of the arrow (along its sliding axis, in pixels) so that the
-		 * arrow of length [arrowLength] stays within [available] space and keeps at least
-		 * [cornerRadius] + [margin] distance from both rounded corners. Returns the offset of the
-		 * arrow's leading edge.
-		 */
-		internal fun clampArrowOffset(
-			center: Float,
-			arrowLength: Float,
-			available: Float,
-			cornerRadius: Float,
-			margin: Float,
-		): Float {
-			val min = cornerRadius + margin
-			val max = available - arrowLength - cornerRadius - margin
-			val leadingEdge = center - arrowLength / 2f
-			return leadingEdge.coerceIn(min, maxOf(min, max))
-		}
+        /**
+         * Clamps the desired [center] of the arrow (along its sliding axis, in pixels) so that the
+         * arrow of length [arrowLength] stays within [available] space and keeps at least
+         * [cornerRadius] + [margin] distance from both rounded corners. Returns the offset of the
+         * arrow's leading edge.
+         */
+        internal fun clampArrowOffset(
+            center: Float,
+            arrowLength: Float,
+            available: Float,
+            cornerRadius: Float,
+            margin: Float,
+        ): Float {
+            val min = cornerRadius + margin
+            val max = available - arrowLength - cornerRadius - margin
+            val leadingEdge = center - arrowLength / 2f
+            return leadingEdge.coerceIn(min, maxOf(min, max))
+        }
 
-		/**
-		 * Converts a center-relative anchor (reveal center offset from the composable's outer
-		 * center) to a shape-local coordinate along the arrow's sliding axis.
-		 *
-		 * For horizontal arrows (Top/Bottom) the sliding axis is the width; for vertical arrows
-		 * (Start/End) it is the height.
-		 */
-		internal fun shapeLocalAnchor(arrow: Arrow, offset: Float, size: Size): Float = when (arrow) {
-			is TopInternal, is BottomInternal -> size.width / 2f + offset
-			is StartInternal, is EndInternal -> size.height / 2f + offset
-		}
+        /**
+         * Converts a center-relative anchor (reveal center offset from the composable's outer
+         * center) to a shape-local coordinate along the arrow's sliding axis.
+         *
+         * For horizontal arrows (Top/Bottom) the sliding axis is the width; for vertical arrows
+         * (Start/End) it is the height.
+         */
+        internal fun shapeLocalAnchor(arrow: Arrow, offset: Float, size: Size): Float =
+            when (arrow) {
+                is TopInternal, is BottomInternal -> size.width / 2f + offset
+                is StartInternal, is EndInternal -> size.height / 2f + offset
+            }
 
-		private fun Alignment.Horizontal.cornerRadiusOffset(
-			cornerRadius: Float,
-			layoutDirection: LayoutDirection,
-		): Float = when (this) {
-			Alignment.Start -> cornerRadius
-			Alignment.End -> -cornerRadius
-			else -> 0f
-		}.let { if (layoutDirection == LayoutDirection.Rtl) -it else it }
+        private fun Alignment.Horizontal.cornerRadiusOffset(
+            cornerRadius: Float,
+            layoutDirection: LayoutDirection,
+        ): Float = when (this) {
+            Alignment.Start -> cornerRadius
+            Alignment.End -> -cornerRadius
+            else -> 0f
+        }.let { if (layoutDirection == LayoutDirection.Rtl) -it else it }
 
-		private fun Alignment.Vertical.cornerRadiusOffset(cornerRadius: Float): Float = when (this) {
-			Alignment.Top -> cornerRadius
-			Alignment.Bottom -> -cornerRadius
-			else -> 0f
-		}
-	}
+        private fun Alignment.Vertical.cornerRadiusOffset(cornerRadius: Float): Float =
+            when (this) {
+                Alignment.Top -> cornerRadius
+                Alignment.Bottom -> -cornerRadius
+                else -> 0f
+            }
+    }
 
-	public val width: Dp
-	public val height: Dp
+    public val width: Dp
+    public val height: Dp
 
-	/**
-	 * Whether this arrow dynamically points towards the center of the reveal area. See the
-	 * `anchorToReveal` parameter of the [start], [top], [end] and [bottom] factory functions.
-	 */
-	public val anchorToReveal: Boolean
+    /**
+     * Whether this arrow dynamically points towards the center of the reveal area. See the
+     * `anchorToReveal` parameter of the [start], [top], [end] and [bottom] factory functions.
+     */
+    public val anchorToReveal: Boolean
 
-	/**
-	 * [PaddingValues] that must be applied to Balloon content to account for arrow.
-	 */
-	public val padding: PaddingValues
+    /**
+     * [PaddingValues] that must be applied to Balloon content to account for arrow.
+     */
+    public val padding: PaddingValues
 
-	/**
-	 * Returns [Path] that renders arrow.
-	 */
-	public fun path(density: Density): Path
+    /**
+     * Returns [Path] that renders arrow.
+     */
+    public fun path(density: Density): Path
 
-	/**
-	 * Returns [Offset] which must be applied to [Path] returned by [path] when shape is rendered.
-	 *
-	 * When this arrow was created with `anchorToReveal = true` and a non-null [anchor] is provided,
-	 * the arrow is positioned so that it points towards [anchor] (the coordinate of the reveal area
-	 * center along the arrow's sliding axis, in pixels, relative to the balloon), clamped so it does
-	 * not overlap the rounded corners. Otherwise the arrow is positioned via its alignment.
-	 */
-	public fun offset(
-		density: Density,
-		size: Size,
-		cornerRadius: Float,
-		layoutDirection: LayoutDirection,
-		anchor: Float? = null,
-	): Offset
+    /**
+     * Returns [Offset] which must be applied to [Path] returned by [path] when shape is rendered.
+     *
+     * When this arrow was created with `anchorToReveal = true` and a non-null [anchor] is provided,
+     * the arrow is positioned so that it points towards [anchor] (the coordinate of the reveal area
+     * center along the arrow's sliding axis, in pixels, relative to the balloon), clamped so it does
+     * not overlap the rounded corners. Otherwise the arrow is positioned via its alignment.
+     */
+    public fun offset(
+        density: Density,
+        size: Size,
+        cornerRadius: Float,
+        layoutDirection: LayoutDirection,
+        anchor: Float? = null,
+    ): Offset
 
-	private class StartInternal(
-		override val width: Dp,
-		override val height: Dp,
-		private val verticalAlignment: Alignment.Vertical,
-		override val anchorToReveal: Boolean = false,
-		private val cornerMargin: Dp = DefaultCornerMargin,
-	) : Arrow {
+    private class StartInternal(
+        override val width: Dp,
+        override val height: Dp,
+        private val verticalAlignment: Alignment.Vertical,
+        override val anchorToReveal: Boolean = false,
+        private val cornerMargin: Dp = DefaultCornerMargin,
+    ) : Arrow {
 
-		override val padding: PaddingValues = PaddingValues.Absolute(left = width)
+        override val padding: PaddingValues = PaddingValues.Absolute(left = width)
 
-		override fun path(density: Density): Path = with(density) {
-			Path().apply {
-				moveTo(0f, height.toPx() / 2f)
-				lineTo(width.toPx(), 0f)
-				lineTo(width.toPx(), height.toPx())
-				close()
-			}
-		}
+        override fun path(density: Density): Path = with(density) {
+            Path().apply {
+                moveTo(0f, height.toPx() / 2f)
+                lineTo(width.toPx(), 0f)
+                lineTo(width.toPx(), height.toPx())
+                close()
+            }
+        }
 
-		override fun offset(
-			density: Density,
-			size: Size,
-			cornerRadius: Float,
-			layoutDirection: LayoutDirection,
-			anchor: Float?,
-		): Offset = with(density) {
-			Offset(
-				x = 0f,
-				y = if (anchorToReveal && anchor != null) {
-					clampArrowOffset(
-						center = anchor,
-						arrowLength = height.toPx(),
-						available = size.height,
-						cornerRadius = cornerRadius,
-						margin = cornerMargin.toPx(),
-					)
-				} else {
-					verticalAlignment.align(
-						size = height.roundToPx(),
-						space = size.height.toInt(),
-					).toFloat() +
-						verticalAlignment.cornerRadiusOffset(cornerRadius)
-				},
-			)
-		}
-	}
+        override fun offset(
+            density: Density,
+            size: Size,
+            cornerRadius: Float,
+            layoutDirection: LayoutDirection,
+            anchor: Float?,
+        ): Offset = with(density) {
+            Offset(
+                x = 0f,
+                y = if (anchorToReveal && anchor != null) {
+                    clampArrowOffset(
+                        center = anchor,
+                        arrowLength = height.toPx(),
+                        available = size.height,
+                        cornerRadius = cornerRadius,
+                        margin = cornerMargin.toPx(),
+                    )
+                } else {
+                    verticalAlignment.align(
+                        size = height.roundToPx(),
+                        space = size.height.toInt(),
+                    ).toFloat() +
+                        verticalAlignment.cornerRadiusOffset(cornerRadius)
+                },
+            )
+        }
+    }
 
-	private class TopInternal(
-		override val width: Dp,
-		override val height: Dp,
-		private val horizontalAlignment: Alignment.Horizontal,
-		override val anchorToReveal: Boolean = false,
-		private val cornerMargin: Dp = DefaultCornerMargin,
-	) : Arrow {
+    private class TopInternal(
+        override val width: Dp,
+        override val height: Dp,
+        private val horizontalAlignment: Alignment.Horizontal,
+        override val anchorToReveal: Boolean = false,
+        private val cornerMargin: Dp = DefaultCornerMargin,
+    ) : Arrow {
 
-		override val padding: PaddingValues = PaddingValues.Absolute(top = height)
+        override val padding: PaddingValues = PaddingValues.Absolute(top = height)
 
-		override fun path(density: Density): Path = with(density) {
-			Path().apply {
-				moveTo(0f, height.toPx())
-				lineTo(width.toPx() / 2f, 0f)
-				lineTo(width.toPx(), height.toPx())
-				close()
-			}
-		}
+        override fun path(density: Density): Path = with(density) {
+            Path().apply {
+                moveTo(0f, height.toPx())
+                lineTo(width.toPx() / 2f, 0f)
+                lineTo(width.toPx(), height.toPx())
+                close()
+            }
+        }
 
-		override fun offset(
-			density: Density,
-			size: Size,
-			cornerRadius: Float,
-			layoutDirection: LayoutDirection,
-			anchor: Float?,
-		): Offset = with(density) {
-			Offset(
-				x = if (anchorToReveal && anchor != null) {
-					clampArrowOffset(
-						center = anchor,
-						arrowLength = width.toPx(),
-						available = size.width,
-						cornerRadius = cornerRadius,
-						margin = cornerMargin.toPx(),
-					)
-				} else {
-					horizontalAlignment.align(
-						size = width.roundToPx(),
-						space = size.width.toInt(),
-						layoutDirection = layoutDirection,
-					).toFloat() +
-						horizontalAlignment.cornerRadiusOffset(
-							cornerRadius,
-							layoutDirection,
-						)
-				},
-				y = 0f,
-			)
-		}
-	}
+        override fun offset(
+            density: Density,
+            size: Size,
+            cornerRadius: Float,
+            layoutDirection: LayoutDirection,
+            anchor: Float?,
+        ): Offset = with(density) {
+            Offset(
+                x = if (anchorToReveal && anchor != null) {
+                    clampArrowOffset(
+                        center = anchor,
+                        arrowLength = width.toPx(),
+                        available = size.width,
+                        cornerRadius = cornerRadius,
+                        margin = cornerMargin.toPx(),
+                    )
+                } else {
+                    horizontalAlignment.align(
+                        size = width.roundToPx(),
+                        space = size.width.toInt(),
+                        layoutDirection = layoutDirection,
+                    ).toFloat() +
+                        horizontalAlignment.cornerRadiusOffset(
+                            cornerRadius,
+                            layoutDirection,
+                        )
+                },
+                y = 0f,
+            )
+        }
+    }
 
-	private class EndInternal(
-		override val width: Dp,
-		override val height: Dp,
-		private val verticalAlignment: Alignment.Vertical,
-		override val anchorToReveal: Boolean = false,
-		private val cornerMargin: Dp = DefaultCornerMargin,
-	) : Arrow {
+    private class EndInternal(
+        override val width: Dp,
+        override val height: Dp,
+        private val verticalAlignment: Alignment.Vertical,
+        override val anchorToReveal: Boolean = false,
+        private val cornerMargin: Dp = DefaultCornerMargin,
+    ) : Arrow {
 
-		override val padding: PaddingValues = PaddingValues.Absolute(right = width)
+        override val padding: PaddingValues = PaddingValues.Absolute(right = width)
 
-		override fun path(density: Density): Path = with(density) {
-			Path().apply {
-				lineTo(width.toPx(), height.toPx() / 2f)
-				lineTo(0f, height.toPx())
-				close()
-			}
-		}
+        override fun path(density: Density): Path = with(density) {
+            Path().apply {
+                lineTo(width.toPx(), height.toPx() / 2f)
+                lineTo(0f, height.toPx())
+                close()
+            }
+        }
 
-		override fun offset(
-			density: Density,
-			size: Size,
-			cornerRadius: Float,
-			layoutDirection: LayoutDirection,
-			anchor: Float?,
-		): Offset = with(density) {
-			Offset(
-				x = size.width - width.toPx(),
-				y = if (anchorToReveal && anchor != null) {
-					clampArrowOffset(
-						center = anchor,
-						arrowLength = height.toPx(),
-						available = size.height,
-						cornerRadius = cornerRadius,
-						margin = cornerMargin.toPx(),
-					)
-				} else {
-					verticalAlignment.align(
-						size = height.roundToPx(),
-						space = size.height.toInt(),
-					).toFloat() +
-						verticalAlignment.cornerRadiusOffset(cornerRadius)
-				},
-			)
-		}
-	}
+        override fun offset(
+            density: Density,
+            size: Size,
+            cornerRadius: Float,
+            layoutDirection: LayoutDirection,
+            anchor: Float?,
+        ): Offset = with(density) {
+            Offset(
+                x = size.width - width.toPx(),
+                y = if (anchorToReveal && anchor != null) {
+                    clampArrowOffset(
+                        center = anchor,
+                        arrowLength = height.toPx(),
+                        available = size.height,
+                        cornerRadius = cornerRadius,
+                        margin = cornerMargin.toPx(),
+                    )
+                } else {
+                    verticalAlignment.align(
+                        size = height.roundToPx(),
+                        space = size.height.toInt(),
+                    ).toFloat() +
+                        verticalAlignment.cornerRadiusOffset(cornerRadius)
+                },
+            )
+        }
+    }
 
-	private class BottomInternal(
-		override val width: Dp,
-		override val height: Dp,
-		private val horizontalAlignment: Alignment.Horizontal,
-		override val anchorToReveal: Boolean = false,
-		private val cornerMargin: Dp = DefaultCornerMargin,
-	) : Arrow {
+    private class BottomInternal(
+        override val width: Dp,
+        override val height: Dp,
+        private val horizontalAlignment: Alignment.Horizontal,
+        override val anchorToReveal: Boolean = false,
+        private val cornerMargin: Dp = DefaultCornerMargin,
+    ) : Arrow {
 
-		override val padding: PaddingValues = PaddingValues.Absolute(bottom = height)
+        override val padding: PaddingValues = PaddingValues.Absolute(bottom = height)
 
-		override fun path(density: Density): Path = with(density) {
-			Path().apply {
-				lineTo(width.toPx() / 2f, height.toPx())
-				lineTo(width.toPx(), 0f)
-				close()
-			}
-		}
+        override fun path(density: Density): Path = with(density) {
+            Path().apply {
+                lineTo(width.toPx() / 2f, height.toPx())
+                lineTo(width.toPx(), 0f)
+                close()
+            }
+        }
 
-		override fun offset(
-			density: Density,
-			size: Size,
-			cornerRadius: Float,
-			layoutDirection: LayoutDirection,
-			anchor: Float?,
-		): Offset = with(density) {
-			Offset(
-				x = if (anchorToReveal && anchor != null) {
-					clampArrowOffset(
-						center = anchor,
-						arrowLength = width.toPx(),
-						available = size.width,
-						cornerRadius = cornerRadius,
-						margin = cornerMargin.toPx(),
-					)
-				} else {
-					horizontalAlignment.align(
-						width.roundToPx(),
-						size.width.toInt(),
-						layoutDirection,
-					).toFloat() +
-						horizontalAlignment.cornerRadiusOffset(
-							cornerRadius,
-							layoutDirection,
-						)
-				},
-				y = size.height - height.toPx(),
-			)
-		}
-	}
+        override fun offset(
+            density: Density,
+            size: Size,
+            cornerRadius: Float,
+            layoutDirection: LayoutDirection,
+            anchor: Float?,
+        ): Offset = with(density) {
+            Offset(
+                x = if (anchorToReveal && anchor != null) {
+                    clampArrowOffset(
+                        center = anchor,
+                        arrowLength = width.toPx(),
+                        available = size.width,
+                        cornerRadius = cornerRadius,
+                        margin = cornerMargin.toPx(),
+                    )
+                } else {
+                    horizontalAlignment.align(
+                        width.roundToPx(),
+                        size.width.toInt(),
+                        layoutDirection,
+                    ).toFloat() +
+                        horizontalAlignment.cornerRadiusOffset(
+                            cornerRadius,
+                            layoutDirection,
+                        )
+                },
+                y = size.height - height.toPx(),
+            )
+        }
+    }
 }

--- a/reveal-shapes/src/commonMain/kotlin/com/svenjacobs/reveal/shapes/balloon/Balloon.kt
+++ b/reveal-shapes/src/commonMain/kotlin/com/svenjacobs/reveal/shapes/balloon/Balloon.kt
@@ -25,23 +25,23 @@ import com.svenjacobs.reveal.LocalRevealOverlayArrowAnchor
  */
 @Composable
 public fun Balloon(
-	arrow: Arrow,
-	backgroundColor: Color,
-	modifier: Modifier = Modifier,
-	cornerRadius: Dp = 8.dp,
-	elevation: Dp = 0.dp,
-	contentAlignment: Alignment = Alignment.TopStart,
-	content: @Composable BoxScope.() -> Unit,
+    arrow: Arrow,
+    backgroundColor: Color,
+    modifier: Modifier = Modifier,
+    cornerRadius: Dp = 8.dp,
+    elevation: Dp = 0.dp,
+    contentAlignment: Alignment = Alignment.TopStart,
+    content: @Composable BoxScope.() -> Unit,
 ) {
-	Balloon(
-		arrow = arrow,
-		modifier = modifier,
-		backgroundModifier = Modifier.background(color = backgroundColor),
-		cornerRadius = cornerRadius,
-		elevation = elevation,
-		contentAlignment = contentAlignment,
-		content = content,
-	)
+    Balloon(
+        arrow = arrow,
+        modifier = modifier,
+        backgroundModifier = Modifier.background(color = backgroundColor),
+        cornerRadius = cornerRadius,
+        elevation = elevation,
+        contentAlignment = contentAlignment,
+        content = content,
+    )
 }
 
 /**
@@ -54,57 +54,57 @@ public fun Balloon(
  */
 @Composable
 public fun Balloon(
-	arrow: Arrow,
-	backgroundBrush: Brush,
-	modifier: Modifier = Modifier,
-	backgroundAlpha: Float = 1.0f,
-	cornerRadius: Dp = 8.dp,
-	elevation: Dp = 0.dp,
-	contentAlignment: Alignment = Alignment.TopStart,
-	content: @Composable BoxScope.() -> Unit,
+    arrow: Arrow,
+    backgroundBrush: Brush,
+    modifier: Modifier = Modifier,
+    backgroundAlpha: Float = 1.0f,
+    cornerRadius: Dp = 8.dp,
+    elevation: Dp = 0.dp,
+    contentAlignment: Alignment = Alignment.TopStart,
+    content: @Composable BoxScope.() -> Unit,
 ) {
-	Balloon(
-		arrow = arrow,
-		modifier = modifier,
-		backgroundModifier = Modifier.background(
-			brush = backgroundBrush,
-			alpha = backgroundAlpha,
-		),
-		cornerRadius = cornerRadius,
-		elevation = elevation,
-		contentAlignment = contentAlignment,
-		content = content,
-	)
+    Balloon(
+        arrow = arrow,
+        modifier = modifier,
+        backgroundModifier = Modifier.background(
+            brush = backgroundBrush,
+            alpha = backgroundAlpha,
+        ),
+        cornerRadius = cornerRadius,
+        elevation = elevation,
+        contentAlignment = contentAlignment,
+        content = content,
+    )
 }
 
 @Composable
 private fun Balloon(
-	arrow: Arrow,
-	cornerRadius: Dp,
-	elevation: Dp,
-	contentAlignment: Alignment,
-	modifier: Modifier = Modifier,
-	backgroundModifier: Modifier = Modifier,
-	content: @Composable BoxScope.() -> Unit,
+    arrow: Arrow,
+    cornerRadius: Dp,
+    elevation: Dp,
+    contentAlignment: Alignment,
+    modifier: Modifier = Modifier,
+    backgroundModifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit,
 ) {
-	// When the arrow should point towards the reveal area, read the anchor published by the reveal
-	// overlay. Exactly one axis is provided depending on the arrangement (offsetX for top/bottom,
-	// offsetY for start/end), so picking the non-null one yields the correct value for this arrow.
-	// Reading the snapshot state here recomposes (and rebuilds the shape) when the anchor changes.
-	val arrowAnchor = if (arrow.anchorToReveal) {
-		LocalRevealOverlayArrowAnchor.current?.let { it.offsetX ?: it.offsetY }
-	} else {
-		null
-	}
-	val shape = BalloonShape(arrow, cornerRadius, LocalDensity.current, arrowAnchor)
+    // When the arrow should point towards the reveal area, read the anchor published by the reveal
+    // overlay. Exactly one axis is provided depending on the arrangement (offsetX for top/bottom,
+    // offsetY for start/end), so picking the non-null one yields the correct value for this arrow.
+    // Reading the snapshot state here recomposes (and rebuilds the shape) when the anchor changes.
+    val arrowAnchor = if (arrow.anchorToReveal) {
+        LocalRevealOverlayArrowAnchor.current?.let { it.offsetX ?: it.offsetY }
+    } else {
+        null
+    }
+    val shape = BalloonShape(arrow, cornerRadius, LocalDensity.current, arrowAnchor)
 
-	Box(
-		modifier = modifier
-			.shadow(elevation, shape)
-			.clip(shape)
-			.then(backgroundModifier)
-			.padding(arrow.padding),
-		contentAlignment = contentAlignment,
-		content = content,
-	)
+    Box(
+        modifier = modifier
+            .shadow(elevation, shape)
+            .clip(shape)
+            .then(backgroundModifier)
+            .padding(arrow.padding),
+        contentAlignment = contentAlignment,
+        content = content,
+    )
 }

--- a/reveal-shapes/src/commonMain/kotlin/com/svenjacobs/reveal/shapes/balloon/BalloonShape.kt
+++ b/reveal-shapes/src/commonMain/kotlin/com/svenjacobs/reveal/shapes/balloon/BalloonShape.kt
@@ -10,33 +10,33 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 
 internal fun BalloonShape(
-	arrow: Arrow,
-	cornerRadius: Dp,
-	density: Density,
-	arrowAnchor: Float? = null,
+    arrow: Arrow,
+    cornerRadius: Dp,
+    density: Density,
+    arrowAnchor: Float? = null,
 ): Shape = GenericShape { size, layoutDirection ->
-	val cornerRadiusPx = with(density) { cornerRadius.toPx() }
-	val arrowPath = arrow.path(density)
-	// arrowAnchor is stored as a center-relative offset (reveal center minus composable outer
-	// center). Convert to the shape-local coordinate along the arrow's sliding axis so that
-	// clampArrowOffset receives a position within [0, size].
-	val localAnchor = arrowAnchor?.let { Arrow.shapeLocalAnchor(arrow, it, size) }
-	val arrowOffset = arrow.offset(density, size, cornerRadiusPx, layoutDirection, localAnchor)
+    val cornerRadiusPx = with(density) { cornerRadius.toPx() }
+    val arrowPath = arrow.path(density)
+    // arrowAnchor is stored as a center-relative offset (reveal center minus composable outer
+    // center). Convert to the shape-local coordinate along the arrow's sliding axis so that
+    // clampArrowOffset receives a position within [0, size].
+    val localAnchor = arrowAnchor?.let { Arrow.shapeLocalAnchor(arrow, it, size) }
+    val arrowOffset = arrow.offset(density, size, cornerRadiusPx, layoutDirection, localAnchor)
 
-	addRoundRect(
-		with(density) {
-			RoundRect(
-				left = arrow.padding.calculateLeftPadding(layoutDirection).toPx(),
-				top = arrow.padding.calculateTopPadding().toPx(),
-				right = size.width - arrow.padding.calculateRightPadding(layoutDirection).toPx(),
-				bottom = size.height - arrow.padding.calculateBottomPadding().toPx(),
-				cornerRadius = CornerRadius(cornerRadiusPx),
-			)
-		},
-	)
+    addRoundRect(
+        with(density) {
+            RoundRect(
+                left = arrow.padding.calculateLeftPadding(layoutDirection).toPx(),
+                top = arrow.padding.calculateTopPadding().toPx(),
+                right = size.width - arrow.padding.calculateRightPadding(layoutDirection).toPx(),
+                bottom = size.height - arrow.padding.calculateBottomPadding().toPx(),
+                cornerRadius = CornerRadius(cornerRadiusPx),
+            )
+        },
+    )
 
-	addPath(
-		arrowPath,
-		offset = arrowOffset,
-	)
+    addPath(
+        arrowPath,
+        offset = arrowOffset,
+    )
 }

--- a/reveal-shapes/src/commonTest/kotlin/com/svenjacobs/reveal/shapes/balloon/ArrowTest.kt
+++ b/reveal-shapes/src/commonTest/kotlin/com/svenjacobs/reveal/shapes/balloon/ArrowTest.kt
@@ -8,57 +8,57 @@ import kotlin.test.assertEquals
  */
 class ArrowTest {
 
-	// available=200, arrowLength=20, cornerRadius=8, margin=4
-	// min = cornerRadius + margin = 12
-	// max = available - arrowLength - cornerRadius - margin = 200 - 20 - 8 - 4 = 168
+    // available=200, arrowLength=20, cornerRadius=8, margin=4
+    // min = cornerRadius + margin = 12
+    // max = available - arrowLength - cornerRadius - margin = 200 - 20 - 8 - 4 = 168
 
-	@Test
-	fun centerWithinRangeMapsToLeadingEdge() {
-		// center 100 -> leading edge 100 - 10 = 90 (within [12, 168])
-		assertEquals(
-			expected = 90f,
-			actual = clamp(center = 100f),
-		)
-	}
+    @Test
+    fun centerWithinRangeMapsToLeadingEdge() {
+        // center 100 -> leading edge 100 - 10 = 90 (within [12, 168])
+        assertEquals(
+            expected = 90f,
+            actual = clamp(center = 100f),
+        )
+    }
 
-	@Test
-	fun clampsToStartCorner() {
-		// center near the start edge would place the arrow over the corner -> clamp to min
-		assertEquals(
-			expected = 12f,
-			actual = clamp(center = 0f),
-		)
-	}
+    @Test
+    fun clampsToStartCorner() {
+        // center near the start edge would place the arrow over the corner -> clamp to min
+        assertEquals(
+            expected = 12f,
+            actual = clamp(center = 0f),
+        )
+    }
 
-	@Test
-	fun clampsToEndCorner() {
-		// center near the end edge would place the arrow over the corner -> clamp to max
-		assertEquals(
-			expected = 168f,
-			actual = clamp(center = 200f),
-		)
-	}
+    @Test
+    fun clampsToEndCorner() {
+        // center near the end edge would place the arrow over the corner -> clamp to max
+        assertEquals(
+            expected = 168f,
+            actual = clamp(center = 200f),
+        )
+    }
 
-	@Test
-	fun degenerateSpaceFallsBackToMin() {
-		// When the bubble is too small for the margins, max < min, so the leading edge is min.
-		assertEquals(
-			expected = 12f,
-			actual = Arrow.clampArrowOffset(
-				center = 25f,
-				arrowLength = 20f,
-				available = 30f,
-				cornerRadius = 8f,
-				margin = 4f,
-			),
-		)
-	}
+    @Test
+    fun degenerateSpaceFallsBackToMin() {
+        // When the bubble is too small for the margins, max < min, so the leading edge is min.
+        assertEquals(
+            expected = 12f,
+            actual = Arrow.clampArrowOffset(
+                center = 25f,
+                arrowLength = 20f,
+                available = 30f,
+                cornerRadius = 8f,
+                margin = 4f,
+            ),
+        )
+    }
 
-	private fun clamp(center: Float): Float = Arrow.clampArrowOffset(
-		center = center,
-		arrowLength = 20f,
-		available = 200f,
-		cornerRadius = 8f,
-		margin = 4f,
-	)
+    private fun clamp(center: Float): Float = Arrow.clampArrowOffset(
+        center = center,
+        arrowLength = 20f,
+        available = 200f,
+        cornerRadius = 8f,
+        margin = 4f,
+    )
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,36 +1,36 @@
 @file:Suppress("UnstableApiUsage")
 
 pluginManagement {
-	repositories {
-		google()
-		mavenCentral()
-		gradlePluginPortal()
-		maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-		maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
-	}
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
+    }
 
-	includeBuild("convention-plugins")
+    includeBuild("convention-plugins")
 }
 
 plugins {
-	id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {
-	repositories {
-		google()
-		mavenCentral()
-		maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-		maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
-	}
+    repositories {
+        google()
+        mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
+    }
 }
 
 rootProject.name = "Reveal"
 
 include(
-	":reveal-common",
-	":reveal-core",
-	":reveal-shapes",
-	":reveal-compat-android",
-	":android-tests",
+    ":reveal-common",
+    ":reveal-core",
+    ":reveal-shapes",
+    ":reveal-compat-android",
+    ":android-tests",
 )


### PR DESCRIPTION
## Summary
- Switch project-wide Kotlin/Gradle indentation from tabs to 4 spaces (`.editorconfig` + reformatted sources in `reveal-*`, `convention-plugins`, `demo-app`)
- Add `AGENTS.md` describing project structure, build/test commands, code style and testing expectations for AI coding agents, symlinked as `CLAUDE.md` and `.github/copilot-instructions.md`
- Mark `Arrow` (`reveal-shapes`) as `@Immutable`: all implementations are private, sealed, and fully immutable, so this lets `Balloon()` skip recomposition when the same `Arrow` instance is reused
- Fix a Compose lint "slot invoked in more than one place" warning in `DimRevealOverlayEffect` by routing the `content` slot through `movableContentWithReceiverOf`

## Test plan
- [x] `./gradlew lintKotlin` passes
- [x] `./gradlew :reveal-shapes:testAndroidHostTest :reveal-shapes:desktopTest :reveal-shapes:jsBrowserTest :reveal-shapes:wasmJsBrowserTest` pass
- [x] `./gradlew apiDump` produces no diff (annotations don't affect the binary-compatibility-validator dump)
- [x] `:reveal-core:compileKotlinDesktop` / `:reveal-core:compileAndroidMain` compile cleanly
- [ ] CI (`verify-pr.yml`): `check`, `verifyRoborazziDebug`, `connectedAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)