### PR TITLE
Fix: align() overlay content reports wrong accessibility bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ Reveal(
 ```
 
 The scope of the overlay content composable provides `align()` modifiers to align the item either to
-the start, top, end or bottom of the reveal area.
+the start, top, end or bottom of the reveal area. `align()` must be applied to a direct child of the
+overlay content; it has no effect on elements nested further down the tree.
 
 `Reveal` provides two click listeners: `onRevealableClick` is called when the reveal area is clicked
 with the key of the current revealable as the first argument. `onOverlayClick` is called when the

--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealOverlayAccessibilityTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealOverlayAccessibilityTest.kt
@@ -1,0 +1,212 @@
+package com.svenjacobs.reveal.android.tests
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import com.svenjacobs.reveal.Reveal
+import com.svenjacobs.reveal.RevealCanvas
+import com.svenjacobs.reveal.RevealOverlayArrangement
+import com.svenjacobs.reveal.RevealScope
+import com.svenjacobs.reveal.RevealState
+import com.svenjacobs.reveal.rememberRevealCanvasState
+import com.svenjacobs.reveal.rememberRevealState
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Regression tests for issue #338: composables placed inside overlayContent via
+ * [com.svenjacobs.reveal.RevealOverlayScope.align] must report their actual drawn bounds (not the
+ * full overlay size) so that they are reachable via semantics-based UI automation (Espresso, UI
+ * Automator, Maestro), which locate and tap elements using the bounds reported to the accessibility
+ * tree.
+ */
+class RevealOverlayAccessibilityTest {
+
+    private enum class Keys { Target }
+
+    @get:Rule
+    val composeTestRule: ComposeContentTestRule = createComposeRule()
+
+    @Test
+    fun alignedItemWithTagAppliedBeforeAlignReportsDrawnBoundsAndIsClickable() {
+        assertAlignedItemIsAccessible(testTagAppliedBeforeAlign = true)
+    }
+
+    @Test
+    fun alignedItemWithTagAppliedAfterAlignReportsDrawnBoundsAndIsClickable() {
+        assertAlignedItemIsAccessible(testTagAppliedBeforeAlign = false)
+    }
+
+    @Test
+    fun unalignedSiblingOfAnAlignedItemStaysAccessible() {
+        lateinit var revealState: RevealState
+        lateinit var scope: CoroutineScope
+        var siblingClicked = false
+
+        composeTestRule.setContent {
+            scope = rememberCoroutineScope()
+            revealState = rememberRevealState()
+            val revealCanvasState = rememberRevealCanvasState()
+
+            RevealCanvas(
+                revealCanvasState = revealCanvasState,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                Reveal(
+                    modifier = Modifier.fillMaxSize(),
+                    revealCanvasState = revealCanvasState,
+                    revealState = revealState,
+                    overlayContent = {
+                        // Composed first so that, under the pre-fix full-screen align() bounds, it
+                        // would be pruned from the semantics tree by the aligned item "drawn on top"
+                        // of it (semantics siblings are processed back-to-front).
+                        Box(
+                            modifier = Modifier
+                                .size(48.dp)
+                                .testTag(SIBLING_TAG)
+                                .clickable { siblingClicked = true },
+                        )
+                        Box(
+                            modifier = Modifier
+                                .testTag(OVERLAY_TAG)
+                                .align(verticalArrangement = RevealOverlayArrangement.Bottom)
+                                .size(width = 120.dp, height = 48.dp),
+                        )
+                    },
+                ) {
+                    RevealTarget(Keys.Target)
+                }
+            }
+        }
+
+        revealTargetAndWaitForOverlay(scope, revealState)
+
+        composeTestRule.onNodeWithTag(SIBLING_TAG)
+            .assertExists()
+            .performClick()
+
+        assertTrue("Sibling of aligned overlay item was not clickable", siblingClicked)
+    }
+
+    private fun assertAlignedItemIsAccessible(testTagAppliedBeforeAlign: Boolean) {
+        lateinit var revealState: RevealState
+        lateinit var scope: CoroutineScope
+        var itemClicked = false
+        var overlayClicked = false
+
+        composeTestRule.setContent {
+            scope = rememberCoroutineScope()
+            revealState = rememberRevealState()
+            val revealCanvasState = rememberRevealCanvasState()
+
+            RevealCanvas(
+                revealCanvasState = revealCanvasState,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                Reveal(
+                    modifier = Modifier.fillMaxSize(),
+                    revealCanvasState = revealCanvasState,
+                    revealState = revealState,
+                    onOverlayClick = { overlayClicked = true },
+                    overlayContent = {
+                        val itemModifier = if (testTagAppliedBeforeAlign) {
+                            Modifier
+                                .testTag(OVERLAY_TAG)
+                                .align(verticalArrangement = RevealOverlayArrangement.Bottom)
+                                .clickable { itemClicked = true }
+                        } else {
+                            Modifier
+                                .align(verticalArrangement = RevealOverlayArrangement.Bottom)
+                                .testTag(OVERLAY_TAG)
+                                .clickable { itemClicked = true }
+                        }
+
+                        Box(modifier = itemModifier.size(width = 120.dp, height = 48.dp))
+                    },
+                ) {
+                    RevealTarget(Keys.Target)
+                }
+            }
+        }
+
+        revealTargetAndWaitForOverlay(scope, revealState)
+
+        val root = composeTestRule.onRoot().getUnclippedBoundsInRoot()
+        val overlayBounds = composeTestRule.onNodeWithTag(OVERLAY_TAG).getUnclippedBoundsInRoot()
+
+        assertTrue(
+            "Aligned overlay item reports the full overlay width ($overlayBounds) instead of " +
+                "its own drawn size, root=$root",
+            (overlayBounds.right - overlayBounds.left) < (root.right - root.left),
+        )
+        assertTrue(
+            "Aligned overlay item reports the full overlay height ($overlayBounds) instead of " +
+                "its own drawn size, root=$root",
+            (overlayBounds.bottom - overlayBounds.top) < (root.bottom - root.top),
+        )
+        assertTrue(
+            "Aligned overlay item is not offset from the top as expected by its arrangement",
+            overlayBounds.top > root.top,
+        )
+
+        composeTestRule.onNodeWithTag(OVERLAY_TAG)
+            .assertExists()
+            .performClick()
+
+        assertTrue(
+            "Clicking the aligned overlay item at its reported bounds missed it",
+            itemClicked,
+        )
+        assertFalse(
+            "Click on the aligned overlay item's own bounds incorrectly fell through to the " +
+                "overlay background",
+            overlayClicked,
+        )
+    }
+
+    private fun revealTargetAndWaitForOverlay(scope: CoroutineScope, revealState: RevealState) {
+        scope.launch { revealState.reveal(Keys.Target) }
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag(OVERLAY_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Composable
+    private fun RevealScope.RevealTarget(key: Keys) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(16.dp)
+                    .size(24.dp)
+                    .revealable(key = key, padding = PaddingValues(0.dp)),
+            )
+        }
+    }
+
+    private companion object {
+        const val OVERLAY_TAG = "overlayContent"
+        const val SIBLING_TAG = "overlaySibling"
+    }
+}

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayLayout.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayLayout.kt
@@ -1,0 +1,141 @@
+package com.svenjacobs.reveal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+
+/**
+ * Lays out the [content] of an overlay, placing every direct child at the position derived from the
+ * [RevealOverlayAlignment] parent data attached via [RevealOverlayScope.align]. Children without
+ * that parent data are placed at the top start with loose constraints, matching a plain [Box].
+ *
+ * Positioning children itself (rather than reporting the full overlay size from within a
+ * [Modifier.layout] on each child, as before) ensures that every child's layout node reports its
+ * actual size and on-screen position, so that semantics/accessibility bounds match what is drawn.
+ */
+@Composable
+internal fun RevealOverlayLayout(
+    revealableRect: IntRect,
+    arrowAnchor: RevealOverlayArrowAnchor,
+    modifier: Modifier = Modifier,
+    content: @Composable RevealOverlayScope.() -> Unit,
+) {
+    Layout(
+        content = { RevealOverlayScopeInstance.content() },
+        modifier = modifier,
+    ) { measurables, constraints ->
+        val space = IntSize(width = constraints.maxWidth, height = constraints.maxHeight)
+        val placeables = arrayOfNulls<Placeable>(measurables.size)
+        val layoutRects = arrayOfNulls<IntRect>(measurables.size)
+
+        measurables.forEachIndexed { index, measurable ->
+            when (val alignment = measurable.revealOverlayAlignment) {
+                is RevealOverlayAlignmentHorizontal -> {
+                    val layoutSize = alignment.arrangement.arrange(
+                        revealable = revealableRect,
+                        space = space,
+                        confineHeight = alignment.confineHeight,
+                        layoutDirection = layoutDirection,
+                    )
+                    layoutRects[index] = layoutSize
+                    // Loose constraints (min = 0): the incoming constraints are fixed to the full
+                    // overlay size (RevealOverlayLayout itself uses matchParentSize()), but the
+                    // child should only be bounded by, not forced to, the arranged layout area.
+                    placeables[index] = measurable.measure(
+                        Constraints(maxWidth = layoutSize.width, maxHeight = space.height),
+                    )
+                }
+
+                is RevealOverlayAlignmentVertical -> {
+                    val layoutSize = alignment.arrangement.arrange(
+                        revealable = revealableRect,
+                        space = space,
+                        confineWidth = alignment.confineWidth,
+                    )
+                    layoutRects[index] = layoutSize
+                    placeables[index] = measurable.measure(
+                        Constraints(maxWidth = space.width, maxHeight = layoutSize.height),
+                    )
+                }
+
+                null -> placeables[index] = measurable.measure(
+                    Constraints(maxWidth = space.width, maxHeight = space.height),
+                )
+            }
+        }
+
+        layout(space.width, space.height) {
+            measurables.forEachIndexed { index, measurable ->
+                val placeable = placeables[index] ?: return@forEachIndexed
+
+                when (val alignment = measurable.revealOverlayAlignment) {
+                    is RevealOverlayAlignmentHorizontal -> {
+                        val layoutSize = layoutRects[index] ?: return@forEachIndexed
+                        val x = alignment.arrangement.align(
+                            size = placeable.width,
+                            layout = layoutSize.width,
+                            space = space.width,
+                        )
+                        val y = layoutSize.top +
+                            alignment.verticalAlignment.align(
+                                size = placeable.height,
+                                space = layoutSize.height,
+                            )
+                        val placedX = x.coerceWithin(size = placeable.width, space = space.width)
+                        val placedY = y.coerceWithin(size = placeable.height, space = space.height)
+                        // The content is placed to the side of the reveal area, so the arrow points
+                        // horizontally and slides along the vertical axis towards the reveal center.
+                        // The offset is stored relative to the composable's outer center so that the
+                        // BalloonShape can recover the correct shape-local coordinate via size/2 + offset
+                        // without needing to know the caller's outer padding value.
+                        arrowAnchor.offsetX = null
+                        arrowAnchor.offsetY =
+                            (revealableRect.center.y - placedY - placeable.height / 2).toFloat()
+                        placeable.placeRelative(x = placedX, y = placedY)
+                    }
+
+                    is RevealOverlayAlignmentVertical -> {
+                        val layoutSize = layoutRects[index] ?: return@forEachIndexed
+                        // Using place() instead of placeRelative() because layoutSize and the value
+                        // returned by horizontalAlignment.align() are RTL-aware
+                        val x = layoutSize.left +
+                            alignment.horizontalAlignment.align(
+                                size = placeable.width,
+                                space = layoutSize.width,
+                                layoutDirection = layoutDirection,
+                            )
+                        val y = alignment.arrangement.align(
+                            size = placeable.height,
+                            layout = layoutSize.height,
+                            space = space.height,
+                        )
+                        val placedX = x.coerceWithin(size = placeable.width, space = space.width)
+                        val placedY = y.coerceWithin(size = placeable.height, space = space.height)
+                        // The content is placed above/below the reveal area, so the arrow points
+                        // vertically and slides along the horizontal axis towards the reveal center.
+                        // The offset is stored relative to the composable's outer center so that the
+                        // BalloonShape can recover the correct shape-local coordinate via size/2 + offset
+                        // without needing to know the caller's outer padding value.
+                        arrowAnchor.offsetX =
+                            (revealableRect.center.x - placedX - placeable.width / 2).toFloat()
+                        arrowAnchor.offsetY = null
+                        placeable.place(x = placedX, y = placedY)
+                    }
+
+                    null -> placeable.place(x = 0, y = 0)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Coerces this offset so that an element of [size] is fully contained within [space], shifting it
+ * back into bounds when it would otherwise overflow the start or end of the available space.
+ */
+private fun Int.coerceWithin(size: Int, space: Int): Int =
+    coerceIn(0, (space - size).coerceAtLeast(0))

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayScope.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayScope.kt
@@ -3,9 +3,11 @@ package com.svenjacobs.reveal
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.layout
-import androidx.compose.ui.unit.IntRect
-import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.ParentDataModifierNode
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Density
 
 /**
  * Scope for overlay content which provides Modifiers to align an element relative to the
@@ -23,8 +25,9 @@ public interface RevealOverlayScope {
      * of the reveal area. For instance use it with a vertical alignment of [Alignment.Top] to
      * implement a custom alignment.
      *
-     * Should be one of the first modifiers applied to the element so that other modifiers are
-     * applied after the element was positioned.
+     * Must be applied to a direct child of the overlay content; the modifier has no effect on
+     * elements nested further down the tree. The position within the modifier chain does not
+     * matter.
      *
      * @param horizontalArrangement Horizontal arrangement (start, end)
      * @param verticalAlignment Vertical alignment of element in relation to reveal area
@@ -45,8 +48,9 @@ public interface RevealOverlayScope {
      * of the reveal area. For instance use it with a horizontal alignment of [Alignment.Start] to
      * implement a custom alignment.
      *
-     * Should be one of the first modifiers applied to the element so that other modifiers are
-     * applied after the element was positioned.
+     * Must be applied to a direct child of the overlay content; the modifier has no effect on
+     * elements nested further down the tree. The position within the modifier chain does not
+     * matter.
      *
      * @param verticalArrangement Vertical arrangement (top, bottom)
      * @param horizontalAlignment Horizontal alignment in relation to reveal area
@@ -61,61 +65,20 @@ public interface RevealOverlayScope {
     ): Modifier
 }
 
-internal class RevealOverlayScopeInstance(
-    private val revealableRect: IntRect,
-    private val arrowAnchor: RevealOverlayArrowAnchor,
-) : RevealOverlayScope {
+internal object RevealOverlayScopeInstance : RevealOverlayScope {
 
     override fun Modifier.align(
         horizontalArrangement: RevealOverlayArrangement.Horizontal,
         verticalAlignment: Alignment.Vertical,
         confineHeight: Boolean,
     ): Modifier = this.then(
-        Modifier.layout { measurable, constraints ->
-            val space = IntSize(
-                width = constraints.maxWidth,
-                height = constraints.maxHeight,
-            )
-            val layoutSize = horizontalArrangement.arrange(
-                revealable = revealableRect,
-                space = space,
+        RevealOverlayAlignElement(
+            alignment = RevealOverlayAlignmentHorizontal(
+                arrangement = horizontalArrangement,
+                verticalAlignment = verticalAlignment,
                 confineHeight = confineHeight,
-                layoutDirection = layoutDirection,
-            )
-            // Constrain the content to the available space so it never exceeds the
-            // boundaries of the screen. The width is confined to the arranged layout area
-            // (the space beside the reveal area), the height to the whole available space.
-            val placeable = measurable.measure(
-                constraints.copy(
-                    maxWidth = layoutSize.width,
-                    maxHeight = space.height,
-                ),
-            )
-
-            layout(space.width, space.height) {
-                val x = horizontalArrangement.align(
-                    size = placeable.width,
-                    layout = layoutSize.width,
-                    space = space.width,
-                )
-                val y = layoutSize.top +
-                    verticalAlignment.align(
-                        size = placeable.height,
-                        space = layoutSize.height,
-                    )
-                val placedX = x.coerceWithin(size = placeable.width, space = space.width)
-                val placedY = y.coerceWithin(size = placeable.height, space = space.height)
-                // The content is placed to the side of the reveal area, so the arrow points
-                // horizontally and slides along the vertical axis towards the reveal center.
-                // The offset is stored relative to the composable's outer center so that the
-                // BalloonShape can recover the correct shape-local coordinate via size/2 + offset
-                // without needing to know the caller's outer padding value.
-                arrowAnchor.offsetX = null
-                arrowAnchor.offsetY =
-                    (revealableRect.center.y - placedY - placeable.height / 2).toFloat()
-                placeable.placeRelative(x = placedX, y = placedY)
-            }
-        },
+            ),
+        ),
     )
 
     override fun Modifier.align(
@@ -123,62 +86,58 @@ internal class RevealOverlayScopeInstance(
         horizontalAlignment: Alignment.Horizontal,
         confineWidth: Boolean,
     ): Modifier = this.then(
-        Modifier.layout { measurable, constraints ->
-            val space = IntSize(
-                width = constraints.maxWidth,
-                height = constraints.maxHeight,
-            )
-            val layoutSize = verticalArrangement.arrange(
-                revealable = revealableRect,
-                space = space,
+        RevealOverlayAlignElement(
+            alignment = RevealOverlayAlignmentVertical(
+                arrangement = verticalArrangement,
+                horizontalAlignment = horizontalAlignment,
                 confineWidth = confineWidth,
-            )
-            // Constrain the content to the available space so it never exceeds the
-            // boundaries of the screen. The height is confined to the arranged layout area
-            // (the space above/below the reveal area), the width to the whole available space.
-            val placeable = measurable.measure(
-                constraints.copy(
-                    maxWidth = space.width,
-                    maxHeight = layoutSize.height,
-                ),
-            )
-
-            layout(space.width, space.height) {
-                // Using place() instead of placeRelative() because layoutSize and the value
-                // returned by horizontalAlignment.align() are RTL-aware
-                val x = layoutSize.left +
-                    horizontalAlignment.align(
-                        size = placeable.width,
-                        space = layoutSize.width,
-                        layoutDirection = layoutDirection,
-                    )
-                val y = verticalArrangement.align(
-                    size = placeable.height,
-                    layout = layoutSize.height,
-                    space = space.height,
-                )
-                val placedX = x.coerceWithin(size = placeable.width, space = space.width)
-                val placedY = y.coerceWithin(size = placeable.height, space = space.height)
-                // The content is placed above/below the reveal area, so the arrow points
-                // vertically and slides along the horizontal axis towards the reveal center.
-                // The offset is stored relative to the composable's outer center so that the
-                // BalloonShape can recover the correct shape-local coordinate via size/2 + offset
-                // without needing to know the caller's outer padding value.
-                arrowAnchor.offsetX =
-                    (revealableRect.center.x - placedX - placeable.width / 2).toFloat()
-                arrowAnchor.offsetY = null
-                placeable.place(
-                    x = placedX,
-                    y = placedY,
-                )
-            }
-        },
+            ),
+        ),
     )
 }
 
 /**
- * Coerces this offset so that an element of [size] is fully contained within [space], shifting it
- * back into bounds when it would otherwise overflow the start or end of the available space.
+ * Parent data attached by [RevealOverlayScope.align], read by [RevealOverlayLayout] to measure and
+ * place its children at their real coordinates. Using parent data (rather than [Modifier.layout])
+ * ensures that the layout node of an aligned element always reports its actual size and on-screen
+ * position, so that semantics/accessibility bounds match what is drawn regardless of the order in
+ * which modifiers are applied.
  */
-private fun Int.coerceWithin(size: Int, space: Int): Int =
-    coerceIn(0, (space - size).coerceAtLeast(0))
+internal sealed interface RevealOverlayAlignment
+
+internal data class RevealOverlayAlignmentHorizontal(
+    val arrangement: RevealOverlayArrangement.Horizontal,
+    val verticalAlignment: Alignment.Vertical,
+    val confineHeight: Boolean,
+) : RevealOverlayAlignment
+
+internal data class RevealOverlayAlignmentVertical(
+    val arrangement: RevealOverlayArrangement.Vertical,
+    val horizontalAlignment: Alignment.Horizontal,
+    val confineWidth: Boolean,
+) : RevealOverlayAlignment
+
+internal val IntrinsicMeasurable.revealOverlayAlignment: RevealOverlayAlignment?
+    get() = parentData as? RevealOverlayAlignment
+
+private data class RevealOverlayAlignElement(val alignment: RevealOverlayAlignment) :
+    ModifierNodeElement<RevealOverlayAlignNode>() {
+
+    override fun create(): RevealOverlayAlignNode = RevealOverlayAlignNode(alignment)
+
+    override fun update(node: RevealOverlayAlignNode) {
+        node.alignment = alignment
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "align"
+        value = alignment
+    }
+}
+
+private class RevealOverlayAlignNode(var alignment: RevealOverlayAlignment) :
+    Modifier.Node(),
+    ParentDataModifierNode {
+
+    override fun Density.modifyParentData(parentData: Any?): Any? = alignment
+}

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
@@ -33,8 +33,8 @@ import com.svenjacobs.reveal.ActualRevealable
 import com.svenjacobs.reveal.Key
 import com.svenjacobs.reveal.LocalRevealOverlayArrowAnchor
 import com.svenjacobs.reveal.RevealOverlayArrowAnchor
+import com.svenjacobs.reveal.RevealOverlayLayout
 import com.svenjacobs.reveal.RevealOverlayScope
-import com.svenjacobs.reveal.RevealOverlayScopeInstance
 import com.svenjacobs.reveal.RevealState
 import com.svenjacobs.reveal.effect.RevealOverlayEffect
 import com.svenjacobs.reveal.effect.dim.DimItemState.Gone
@@ -117,21 +117,17 @@ private class DimItemHolder(val revealable: ActualRevealable, val contentAlpha: 
 
         val arrowAnchor = remember { RevealOverlayArrowAnchor() }
 
-        Box(
-            modifier = modifier
-                .matchParentSize()
-                .alpha(contentAlpha.value),
-            content = {
-                CompositionLocalProvider(
-                    LocalRevealOverlayArrowAnchor provides arrowAnchor,
-                ) {
-                    RevealOverlayScopeInstance(
-                        revealableRect = revealable.area.toIntRect(),
-                        arrowAnchor = arrowAnchor,
-                    ).content(revealable.key)
-                }
-            },
-        )
+        CompositionLocalProvider(LocalRevealOverlayArrowAnchor provides arrowAnchor) {
+            RevealOverlayLayout(
+                revealableRect = revealable.area.toIntRect(),
+                arrowAnchor = arrowAnchor,
+                modifier = modifier
+                    .matchParentSize()
+                    .alpha(contentAlpha.value),
+            ) {
+                content(revealable.key)
+            }
+        }
     }
 
     fun DrawScope.draw(density: Density) {


### PR DESCRIPTION
## Summary

Fixes #338

`RevealOverlayScope.align()` used `Modifier.layout {}` to report the **full overlay size** as its own layout bounds while drawing the child at an inner offset. Any semantics (`testTag`, `clickable`, etc.) attached outside that layout modifier therefore inherited full-screen accessibility bounds — making aligned overlay items untappable via Espresso / UI Automator / Maestro (`tapOn: id:`), and pruning other overlay content from the semantics tree since the full-screen node consumed all "unaccounted space" during accessibility traversal.

- `align()` is now a `ParentDataModifierNode` (the same pattern `BoxScope.align` uses) instead of a `Modifier.layout {}`.
- A new internal `RevealOverlayLayout` composable (a custom `Layout`) measures and places each child at its real, drawn coordinates using the parent data, rather than lying about layout bounds.
- This makes the fix correct regardless of modifier order — the previous "should be one of the first modifiers applied" caveat no longer applies (still needs to be a direct child of the overlay content, documented in README/KDoc).
- Public API signatures are unchanged; `apiCheck` passes with no `api/` diff.

## Test plan

- [x] New instrumentation tests (`RevealOverlayAccessibilityTest`): aligned item reports its own drawn bounds and is clickable with `testTag` applied before *and* after `align()`; an unaligned sibling of an aligned item stays reachable
- [x] Existing `RevealOverlayBoundsTest`, `RevealTest` pass unchanged on a connected emulator
- [x] `./gradlew apiCheck` — clean, no public API changes
- [x] `./gradlew :android-tests:verifyRoborazziDebug` — screenshots unchanged (confirms placement math is pixel-identical to before)
- [x] `./gradlew lintKotlin` / `formatKotlin` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)