### PR TITLE
fix: track revealable bounds across layout changes

### DIFF
--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealInModalBottomSheetTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealInModalBottomSheetTest.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput

--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealMovingRevealableTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealMovingRevealableTest.kt
@@ -27,11 +27,11 @@ import com.svenjacobs.reveal.RevealState
 import com.svenjacobs.reveal.effect.dim.DimRevealOverlayEffect
 import com.svenjacobs.reveal.rememberRevealState
 import junit.framework.TestCase.assertTrue
+import kotlin.math.abs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.junit.Rule
 import org.junit.Test
-import kotlin.math.abs
 
 /**
  * Regression test for issue #360: the reveal area must keep tracking the revealable when the

--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealMovingRevealableTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealMovingRevealableTest.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -96,20 +95,25 @@ class RevealMovingRevealableTest {
             composeTestRule.onAllNodesWithTag(OVERLAY_TAG).fetchSemanticsNodes().isNotEmpty()
         }
 
+        // boundsInWindow (not boundsInRoot) is used throughout because the target lives in the
+        // activity's composition root while the overlay content lives in the popup's own root, and
+        // the popup deliberately draws behind the system bars. In root coordinates the two are
+        // offset by the status bar height, which is zero only on an edge-to-edge device.
         val overlayBefore = composeTestRule
             .onNodeWithTag(OVERLAY_TAG)
-            .getUnclippedBoundsInRoot()
+            .fetchSemanticsNode()
+            .boundsInWindow
 
         // Insert content above the target, moving it down while the effect is visible.
         spacerHeight = 200.dp
         composeTestRule.waitForIdle()
 
-        val target = composeTestRule.onNodeWithTag(TARGET_TAG).getUnclippedBoundsInRoot()
-        val overlay = composeTestRule.onNodeWithTag(OVERLAY_TAG).getUnclippedBoundsInRoot()
+        val target = composeTestRule.onNodeWithTag(TARGET_TAG).fetchSemanticsNode().boundsInWindow
+        val overlay = composeTestRule.onNodeWithTag(OVERLAY_TAG).fetchSemanticsNode().boundsInWindow
 
         assertTrue(
             "Overlay content should have moved down with the target, but stayed at $overlayBefore",
-            overlay.top.value > overlayBefore.top.value,
+            overlay.top > overlayBefore.top,
         )
 
         // The overlay is aligned to the start of the reveal area, so it must abut the target's
@@ -117,23 +121,20 @@ class RevealMovingRevealableTest {
         assertTrue(
             "Overlay content should abut the moved reveal area's left edge, but " +
                 "overlay=$overlay target=$target",
-            abs(overlay.right.value - target.left.value) <= TOLERANCE,
+            abs(overlay.right - target.left) <= TOLERANCE,
         )
         assertTrue(
             "Overlay content should be vertically centered on the moved reveal area, but " +
                 "overlay=$overlay target=$target",
-            abs(
-                (overlay.top.value + overlay.bottom.value) /
-                    2f -
-                    (target.top.value + target.bottom.value) /
-                    2f,
-            ) <= TOLERANCE,
+            abs(overlay.center.y - target.center.y) <= TOLERANCE,
         )
     }
 
     private companion object {
         const val TARGET_TAG = "target"
         const val OVERLAY_TAG = "overlayContent"
-        const val TOLERANCE = 0.5f
+
+        // Pixels, since boundsInWindow reports pixels rather than dp.
+        const val TOLERANCE = 1.0f
     }
 }

--- a/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealMovingRevealableTest.kt
+++ b/android-tests/src/androidTest/kotlin/com/svenjacobs/reveal/android/tests/RevealMovingRevealableTest.kt
@@ -1,0 +1,139 @@
+package com.svenjacobs.reveal.android.tests
+
+import androidx.compose.animation.core.snap
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import com.svenjacobs.reveal.Reveal
+import com.svenjacobs.reveal.RevealOverlayArrangement
+import com.svenjacobs.reveal.RevealState
+import com.svenjacobs.reveal.effect.dim.DimRevealOverlayEffect
+import com.svenjacobs.reveal.rememberRevealState
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.junit.Rule
+import org.junit.Test
+import kotlin.math.abs
+
+/**
+ * Regression test for issue #360: the reveal area must keep tracking the revealable when the
+ * element moves after the effect is already shown.
+ *
+ * This mirrors the scenario from the report where content is inserted above the coach target after
+ * the reveal, and also covers the originally reported symptom, where a settling layout pass on some
+ * devices moved the target right after `reveal()` was called. Before the fix, `reveal()` copied the
+ * geometry once and neither the cutout nor the overlay content ever followed, so the effect stayed
+ * permanently offset.
+ */
+class RevealMovingRevealableTest {
+
+    private enum class Keys { Target }
+
+    @get:Rule
+    val composeTestRule: ComposeContentTestRule = createComposeRule()
+
+    @Test
+    fun overlayFollowsRevealableThatMovesAfterReveal() {
+        lateinit var revealState: RevealState
+        lateinit var scope: CoroutineScope
+        var spacerHeight by mutableStateOf(0.dp)
+
+        composeTestRule.setContent {
+            scope = rememberCoroutineScope()
+            revealState = rememberRevealState()
+
+            Reveal(
+                modifier = Modifier.fillMaxSize(),
+                revealState = revealState,
+                // Instant animations so the overlay is fully laid out once it appears.
+                overlayEffect = DimRevealOverlayEffect(
+                    alphaAnimationSpec = snap(),
+                    contentAlphaAnimationSpec = snap(),
+                ),
+                overlayContent = {
+                    Box(
+                        modifier = Modifier
+                            .align(horizontalArrangement = RevealOverlayArrangement.Start)
+                            .size(100.dp)
+                            .testTag(OVERLAY_TAG),
+                    )
+                },
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Spacer(modifier = Modifier.height(spacerHeight))
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .size(48.dp)
+                            .testTag(TARGET_TAG)
+                            .revealable(key = Keys.Target, padding = PaddingValues(0.dp)),
+                    )
+                }
+            }
+        }
+
+        scope.launch { revealState.reveal(Keys.Target) }
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag(OVERLAY_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val overlayBefore = composeTestRule
+            .onNodeWithTag(OVERLAY_TAG)
+            .getUnclippedBoundsInRoot()
+
+        // Insert content above the target, moving it down while the effect is visible.
+        spacerHeight = 200.dp
+        composeTestRule.waitForIdle()
+
+        val target = composeTestRule.onNodeWithTag(TARGET_TAG).getUnclippedBoundsInRoot()
+        val overlay = composeTestRule.onNodeWithTag(OVERLAY_TAG).getUnclippedBoundsInRoot()
+
+        assertTrue(
+            "Overlay content should have moved down with the target, but stayed at $overlayBefore",
+            overlay.top.value > overlayBefore.top.value,
+        )
+
+        // The overlay is aligned to the start of the reveal area, so it must abut the target's
+        // left edge and stay centered on it vertically at the target's new position.
+        assertTrue(
+            "Overlay content should abut the moved reveal area's left edge, but " +
+                "overlay=$overlay target=$target",
+            abs(overlay.right.value - target.left.value) <= TOLERANCE,
+        )
+        assertTrue(
+            "Overlay content should be vertically centered on the moved reveal area, but " +
+                "overlay=$overlay target=$target",
+            abs(
+                (overlay.top.value + overlay.bottom.value) /
+                    2f -
+                    (target.top.value + target.bottom.value) /
+                    2f,
+            ) <= TOLERANCE,
+        )
+    }
+
+    private companion object {
+        const val TARGET_TAG = "target"
+        const val OVERLAY_TAG = "overlayContent"
+        const val TOLERANCE = 0.5f
+    }
+}

--- a/reveal-core/api/desktop/reveal-core.api
+++ b/reveal-core/api/desktop/reveal-core.api
@@ -185,6 +185,11 @@ public final class com/svenjacobs/reveal/RevealShape$RoundRect : com/svenjacobs/
 	public synthetic fun <init> (FLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun asRect-uvyYCjk (J)Landroidx/compose/ui/geometry/Rect;
 	public fun clip-Pq9zytI (JLandroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;)Landroidx/compose/ui/graphics/Path;
+	public final fun copy-0680j_4 (F)Lcom/svenjacobs/reveal/RevealShape$RoundRect;
+	public static synthetic fun copy-0680j_4$default (Lcom/svenjacobs/reveal/RevealShape$RoundRect;FILjava/lang/Object;)Lcom/svenjacobs/reveal/RevealShape$RoundRect;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/svenjacobs/reveal/RevealState {

--- a/reveal-core/api/reveal-core.klib.api
+++ b/reveal-core/api/reveal-core.klib.api
@@ -59,6 +59,10 @@ sealed interface com.svenjacobs.reveal/RevealShape { // com.svenjacobs.reveal/Re
         constructor <init>(androidx.compose.ui.unit/Dp) // com.svenjacobs.reveal/RevealShape.RoundRect.<init>|<init>(androidx.compose.ui.unit.Dp){}[0]
 
         final fun clip(androidx.compose.ui.geometry/Size, androidx.compose.ui.unit/Density, androidx.compose.ui.unit/LayoutDirection): androidx.compose.ui.graphics/Path // com.svenjacobs.reveal/RevealShape.RoundRect.clip|clip(androidx.compose.ui.geometry.Size;androidx.compose.ui.unit.Density;androidx.compose.ui.unit.LayoutDirection){}[0]
+        final fun copy(androidx.compose.ui.unit/Dp = ...): com.svenjacobs.reveal/RevealShape.RoundRect // com.svenjacobs.reveal/RevealShape.RoundRect.copy|copy(androidx.compose.ui.unit.Dp){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.svenjacobs.reveal/RevealShape.RoundRect.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.svenjacobs.reveal/RevealShape.RoundRect.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.svenjacobs.reveal/RevealShape.RoundRect.toString|toString(){}[0]
     }
 
     final object Circle : com.svenjacobs.reveal/RevealShape { // com.svenjacobs.reveal/RevealShape.Circle|null[0]

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Modifiers.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Modifiers.kt
@@ -2,12 +2,13 @@ package com.svenjacobs.reveal
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
-import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.node.GlobalPositionAwareModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 
@@ -29,7 +30,7 @@ public sealed interface OnClick {
  * Registers the element as a revealable item.
  *
  * [key] must be unique in the current scope and should be used for [RevealState.reveal].
- * Internally [Modifier.onGloballyPositioned] is used. Hence elements are only registered after
+ * Registration happens from a layout modifier node, so elements are only known to Reveal after
  * they have been laid out.
  *
  * If the element that this modifier is applied to leaves the composition while the reveal
@@ -71,8 +72,8 @@ public fun Modifier.revealable(
  * Registers the element as a revealable item.
  *
  * Each key in [keys] must be unique in the current scope and should be used for
- * [RevealState.reveal]. Internally [Modifier.onGloballyPositioned] is used. Hence elements are
- * only registered after they have been laid out.
+ * [RevealState.reveal]. Registration happens from a layout modifier node, so elements are only
+ * known to Reveal after they have been laid out.
  *
  * If the element that this modifier is applied to leaves the composition while the reveal
  * effect is shown for the element, the effect is finished.
@@ -113,8 +114,8 @@ public fun Modifier.revealable(
  * Registers the element as a revealable item.
  *
  * Each key specified in [keys] must be unique in the current scope and should be used for
- * [RevealState.reveal]. Internally [Modifier.onGloballyPositioned] is used. Hence elements are
- * only registered after they have been laid out.
+ * [RevealState.reveal]. Registration happens from a layout modifier node, so elements are only
+ * known to Reveal after they have been laid out.
  *
  * If the element that this modifier is applied to leaves the composition while the reveal
  * effect is shown for the element, the effect is finished.
@@ -141,30 +142,132 @@ public fun Modifier.revealable(
     borderStroke: BorderStroke? = null,
     onClick: OnClick? = null,
 ): Modifier = this.then(
-    Modifier
-        .onGloballyPositioned { layoutCoordinates ->
-            keys.forEach { key ->
-                state.addRevealable(
-                    Revealable(
-                        key = key,
-                        shape = shape,
-                        padding = padding,
-                        borderStroke = borderStroke,
-                        layout = Revealable.Layout(
-                            offset = layoutCoordinates.positionInRoot(),
-                            size = layoutCoordinates.size.toSize(),
-                        ),
-                        onClick = onClick,
-                    ),
-                )
-            }
-        }
-        .composed {
-            DisposableEffect(Unit) {
-                onDispose {
-                    keys.forEach(state::removeRevealable)
-                }
-            }
-            this
-        },
+    RevealableElement(
+        keys = keys.toList(),
+        state = state,
+        shape = shape,
+        padding = padding,
+        borderStroke = borderStroke,
+        onClick = onClick,
+    ),
 )
+
+private data class RevealableElement(
+    val keys: List<Key>,
+    val state: RevealState,
+    val shape: RevealShape,
+    val padding: PaddingValues,
+    val borderStroke: BorderStroke?,
+    val onClick: OnClick?,
+) : ModifierNodeElement<RevealableNode>() {
+
+    override fun create(): RevealableNode = RevealableNode(
+        keys = keys,
+        state = state,
+        shape = shape,
+        padding = padding,
+        borderStroke = borderStroke,
+        onClick = onClick,
+    )
+
+    override fun update(node: RevealableNode) {
+        node.update(
+            keys = keys,
+            state = state,
+            shape = shape,
+            padding = padding,
+            borderStroke = borderStroke,
+            onClick = onClick,
+        )
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "revealable"
+        properties["keys"] = keys
+        properties["shape"] = shape
+        properties["padding"] = padding
+        properties["borderStroke"] = borderStroke
+        properties["onClick"] = onClick
+    }
+}
+
+private class RevealableNode(
+    private var keys: List<Key>,
+    private var state: RevealState,
+    private var shape: RevealShape,
+    private var padding: PaddingValues,
+    private var borderStroke: BorderStroke?,
+    private var onClick: OnClick?,
+) : Modifier.Node(),
+    GlobalPositionAwareModifierNode {
+
+    /**
+     * Geometry as of the last layout pass, retained so that registrations can be replayed when
+     * [keys] or [state] change without waiting for another one. `null` until first positioned.
+     */
+    private var layout: Revealable.Layout? = null
+
+    override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+        val layout = Revealable.Layout(
+            offset = coordinates.positionInRoot(),
+            size = coordinates.size.toSize(),
+        )
+        this.layout = layout
+        register(layout)
+    }
+
+    override fun onDetach() {
+        keys.forEach(state::removeRevealable)
+        layout = null
+    }
+
+    fun update(
+        keys: List<Key>,
+        state: RevealState,
+        shape: RevealShape,
+        padding: PaddingValues,
+        borderStroke: BorderStroke?,
+        onClick: OnClick?,
+    ) {
+        val keysChanged = this.keys != keys
+        val stateChanged = this.state !== state
+
+        // Drop registrations this node no longer owns. The previous implementation could not do
+        // this: its DisposableEffect was keyed on Unit, so changing `keys` on a node that stays in
+        // the composition left the old keys behind until the element was disposed.
+        if (keysChanged || stateChanged) {
+            val obsolete = if (stateChanged) this.keys else this.keys - keys.toSet()
+            obsolete.forEach(this.state::removeRevealable)
+        }
+
+        this.keys = keys
+        this.state = state
+        this.shape = shape
+        this.padding = padding
+        this.borderStroke = borderStroke
+        this.onClick = onClick
+
+        // Only a changed key set or state is replayed here; the other properties are picked up by
+        // the next layout pass, as they were before. Registering on every update would write to
+        // RevealState on every recomposition, and since OnClick.Listener and RevealShape.Custom
+        // wrap caller-supplied lambdas that never compare equal, such a write could never settle.
+        if (keysChanged || stateChanged) {
+            layout?.let(::register)
+        }
+    }
+
+    private fun register(layout: Revealable.Layout) {
+        keys.forEach { key ->
+            state.addRevealable(
+                Revealable(
+                    key = key,
+                    shape = shape,
+                    padding = padding,
+                    borderStroke = borderStroke,
+                    layout = layout,
+                    onClick = onClick,
+                ),
+            )
+        }
+    }
+}

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Reveal.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/Reveal.kt
@@ -111,7 +111,7 @@ public fun Reveal(
     // poisons the arithmetic and places the reveal area nowhere.
     var rootOffsetInWindow by remember { mutableStateOf(Offset.Zero) }
 
-    val currentRevealable = remember {
+    val currentRevealable = remember(density, layoutDirection) {
         derivedStateOf {
             revealState.currentRevealable?.toActual(
                 density = density,
@@ -121,7 +121,7 @@ public fun Reveal(
         }
     }
 
-    val previousRevealable = remember {
+    val previousRevealable = remember(density, layoutDirection) {
         derivedStateOf {
             revealState.previousRevealable?.toActual(
                 density = density,

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealScope.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealScope.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 
 /**
@@ -17,7 +16,7 @@ public interface RevealScope {
      * Registers the element as a revealable item.
      *
      * [key] must be unique in the current scope and should be used for [RevealState.reveal].
-     * Internally [Modifier.onGloballyPositioned] is used. Hence elements are only registered after
+     * Registration happens from a layout modifier node, so elements are only known to Reveal after
      * they have been laid out.
      *
      * If the element that this modifier is applied to leaves the composition while the reveal
@@ -48,8 +47,8 @@ public interface RevealScope {
      * Registers the element as a revealable item.
      *
      * Each key in [keys] must be unique in the current scope and should be used for
-     * [RevealState.reveal]. Internally [Modifier.onGloballyPositioned] is used. Hence elements are
-     * only registered after they have been laid out.
+     * [RevealState.reveal]. Registration happens from a layout modifier node, so elements are only
+     * known to Reveal after they have been laid out.
      *
      * If the element that this modifier is applied to leaves the composition while the reveal
      * effect is shown for the element, the effect is finished.
@@ -79,8 +78,8 @@ public interface RevealScope {
      * Registers the element as a revealable item.
      *
      * Each key specified in [keys] must be unique in the current scope and should be used for
-     * [RevealState.reveal]. Internally [Modifier.onGloballyPositioned] is used. Hence elements are
-     * only registered after they have been laid out.
+     * [RevealState.reveal]. Registration happens from a layout modifier node, so elements are only
+     * known to Reveal after they have been laid out.
      *
      * If the element that this modifier is applied to leaves the composition while the reveal
      * effect is shown for the element, the effect is finished.

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealShape.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealShape.kt
@@ -2,13 +2,13 @@ package com.svenjacobs.reveal
 
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect as ComposeRect
 import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.geometry.Rect as ComposeRect
 
 /**
  * Shape of the reveal area.

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealShape.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealShape.kt
@@ -2,13 +2,13 @@ package com.svenjacobs.reveal
 
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect as ComposeRect
 import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.geometry.Rect as ComposeRect
 
 /**
  * Shape of the reveal area.
@@ -36,7 +36,12 @@ public sealed interface RevealShape {
             }
     }
 
-    public class RoundRect(private val cornerSize: Dp) : RevealShape {
+    /**
+     * Value equality matters here: this is the default shape of the `revealable` modifier, so a
+     * fresh instance is allocated on every recomposition. Without `equals` no two [Revealable]s
+     * ever compare equal, which defeats snapshot state deduplication.
+     */
+    public data class RoundRect(private val cornerSize: Dp) : RevealShape {
 
         override fun clip(size: Size, density: Density, layoutDirection: LayoutDirection): Path =
             Path().apply {

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealState.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealState.kt
@@ -70,6 +70,11 @@ public class RevealState internal constructor(
     /**
      * Reveals revealable with given [key]
      *
+     * The reveal area tracks the element for as long as it is revealed: if the element moves or is
+     * resized afterwards — because of a later layout pass, a recomposition, insets settling or
+     * animated content — the effect follows it. There is no need to wait for the layout to become
+     * stable before calling this function.
+     *
      * Might throw [IllegalArgumentException] if the revealable item is not known to Reveal. This
      * might happen if for example the item is in a lazy container and is currently not part of the
      * visible area. It is the duty of the developer to ensure that a revealable item is currently
@@ -136,6 +141,30 @@ public class RevealState internal constructor(
      */
     public fun addRevealable(revealable: Revealable) {
         revealables[revealable.key] = revealable
+
+        // Keep the revealed geometry in sync with later layout passes. onGloballyPositioned fires
+        // again whenever the element moves or is resized, so without this the effect would stay
+        // frozen at the position the element had when reveal() was called.
+        //
+        // Only Layout is carried over, and only when it really changed. The remaining properties
+        // are deliberately kept as captured at reveal time. They come from the modifier call site
+        // and are reallocated on every recomposition, and while most of them compare by value,
+        // OnClick.Listener and RevealShape.Custom wrap caller-supplied lambdas and so cannot.
+        // Assigning the incoming Revealable wholesale would therefore write a never-equal value
+        // into snapshot state from the layout phase, invalidating the composition that reads it,
+        // which reallocates those lambdas and re-triggers this callback — composition would never
+        // go idle. Offset and Size do compare by value, so this converges once the layout settles.
+        currentRevealable?.let { current ->
+            if (current.key == revealable.key && current.layout != revealable.layout) {
+                currentRevealable = current.copy(layout = revealable.layout)
+            }
+        }
+
+        previousRevealable?.let { previous ->
+            if (previous.key == revealable.key && previous.layout != revealable.layout) {
+                previousRevealable = previous.copy(layout = revealable.layout)
+            }
+        }
 
         if (!didRestoreCurrentRevealable && restoreCurrentRevealableKey == revealable.key) {
             currentRevealable = revealable

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/effect/dim/DimRevealOverlayEffect.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.key
-import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.movableContentWithReceiverOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -179,7 +178,10 @@ private fun rememberDimItemHolder(
         targetState.value = toState
     }
 
-    remember {
+    // Keyed on the revealable so that a changed area (the element moved or was resized after being
+    // revealed) reaches both the cutout and the overlay content layout. targetState and
+    // contentAlpha are remembered outside of this, so the alpha animation is not restarted.
+    remember(revealable) {
         DimItemHolder(
             revealable = revealable,
             contentAlpha = contentAlpha,

--- a/reveal-core/src/desktopTest/kotlin/com/svenjacobs/reveal/RevealOverlayGeometryTest.kt
+++ b/reveal-core/src/desktopTest/kotlin/com/svenjacobs/reveal/RevealOverlayGeometryTest.kt
@@ -23,11 +23,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import com.svenjacobs.reveal.effect.dim.DimRevealOverlayEffect
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Tests for the coordinate mapping between [Reveal]'s own composition root, where reveal areas are

--- a/reveal-core/src/desktopTest/kotlin/com/svenjacobs/reveal/RevealOverlayGeometryTest.kt
+++ b/reveal-core/src/desktopTest/kotlin/com/svenjacobs/reveal/RevealOverlayGeometryTest.kt
@@ -2,11 +2,17 @@ package com.svenjacobs.reveal
 
 import androidx.compose.animation.core.snap
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -17,11 +23,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import com.svenjacobs.reveal.effect.dim.DimRevealOverlayEffect
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertTrue
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
  * Tests for the coordinate mapping between [Reveal]'s own composition root, where reveal areas are
@@ -79,6 +85,83 @@ class RevealOverlayGeometryTest {
                 target.top >= catcher.top &&
                 target.bottom <= catcher.bottom,
             "Reveal area should be contained by the overlay, but target=$target catcher=$catcher",
+        )
+    }
+
+    /**
+     * Regression test for issue #360: the reveal area must keep tracking the element when it moves
+     * after the reveal effect is already shown, for example because a settling layout pass or
+     * dynamically added content shifts it. Before the fix, `reveal()` snapshotted the geometry once
+     * and the overlay stayed behind at the original position.
+     */
+    @Test
+    fun revealAreaFollowsTheElementWhenItMovesAfterBeingRevealed() = runComposeUiTest {
+        lateinit var revealState: RevealState
+        lateinit var scope: CoroutineScope
+        var spacerHeight by mutableStateOf(0.dp)
+
+        setContent {
+            revealState = rememberRevealState()
+            scope = rememberCoroutineScope()
+
+            Reveal(
+                modifier = Modifier.fillMaxSize(),
+                revealState = revealState,
+                overlayEffect = DimRevealOverlayEffect(
+                    alphaAnimationSpec = snap(),
+                    contentAlphaAnimationSpec = snap(),
+                ),
+                overlayContent = {
+                    Box(
+                        modifier = Modifier
+                            .align(horizontalArrangement = RevealOverlayArrangement.Start)
+                            .size(80.dp)
+                            .testTag(OVERLAY_TAG),
+                    )
+                },
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Spacer(modifier = Modifier.height(spacerHeight))
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .size(48.dp)
+                            .testTag(TARGET_TAG)
+                            .revealable(key = KEY, padding = PaddingValues(0.dp)),
+                    )
+                }
+            }
+        }
+
+        waitForIdle()
+        scope.launch { revealState.reveal(KEY) }
+        waitUntil(timeoutMillis = 5_000) {
+            onAllNodesWithTag(OVERLAY_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val overlayBefore = onNodeWithTag(OVERLAY_TAG).fetchSemanticsNode().boundsInWindow
+
+        // Push the target down, as a later layout pass or dynamically added content would.
+        spacerHeight = 160.dp
+        waitForIdle()
+
+        val target = onNodeWithTag(TARGET_TAG).fetchSemanticsNode().boundsInWindow
+        val overlay = onNodeWithTag(OVERLAY_TAG).fetchSemanticsNode().boundsInWindow
+
+        assertTrue(
+            overlay.center.y > overlayBefore.center.y,
+            "Overlay content should have moved down with the target, but it stayed at " +
+                "$overlayBefore",
+        )
+        assertTrue(
+            abs(overlay.right - target.left) <= TOLERANCE,
+            "Overlay content should still abut the moved reveal area's left edge, but " +
+                "overlay=$overlay target=$target",
+        )
+        assertTrue(
+            abs(overlay.center.y - target.center.y) <= TOLERANCE,
+            "Overlay content should still be vertically centered on the moved reveal area, but " +
+                "overlay=$overlay target=$target",
         )
     }
 


### PR DESCRIPTION
## Summary

Closes #360.

The reveal effect could be drawn at a stale position and never correct itself. Two independent causes, both of which had to be fixed:

1. `RevealState.internalReveal` copied `revealables[key]` into `currentRevealable` once. `addRevealable` kept the map current on every layout pass but never refreshed `currentRevealable`, so the effect stayed frozen at whatever geometry the element had at the moment `reveal()` was called.
2. `DimRevealOverlayEffect.rememberDimItemHolder` cached the `ActualRevealable` in an unkeyed `remember` inside `key(revealable.key)`, so a new value with the same key but a different area was discarded. Fixing (1) alone changed nothing visible.

The library was already receiving the corrected coordinates — `onGloballyPositioned` fires on every layout pass — and throwing them away.

## Why it looked device-specific

Whether the settling layout pass lands before or after the app's `reveal()` call depends on inset dispatch (gesture vs 3-button nav), display cutout, IME, font scale and first-frame cost. Fast, simple screens settled before the call; others didn't, and losing that race was permanent. Nothing Android-specific was actually broken.

This is also why "only call `reveal()` once the UI is stable" isn't a sufficient answer: it can't be expressed from application code without frame polling, and it does nothing for the case in the issue thread where content added *later* moves the target.

## Changes

**Bounds tracking (#360)**

- `RevealState.addRevealable` carries the new `Layout` onto the current and previous revealable. Only `Layout` is copied, and only on an actual change — the other properties come from the modifier call site and are reallocated every recomposition, and `OnClick.Listener` / `RevealShape.Custom` wrap caller-supplied lambdas. Assigning the incoming `Revealable` wholesale writes a never-equal value into snapshot state from the layout phase, which invalidates the composition that reads it, which reallocates those lambdas and re-triggers the callback — composition never goes idle. `Offset`/`Size` compare by value, so this converges once the layout settles.
- `DimRevealOverlayEffect` keys its holder on the revealable. `targetState` and `contentAlpha` stay outside, so the alpha animation isn't restarted.
- `RevealShape.RoundRect` is now a `data class`. As the default `shape` argument of `Modifier.revealable`, a fresh instance was allocated on every call, so no two `Revealable`s ever compared equal — defeating deduplication on the `mutableStateMapOf` write on every layout pass.
- `Reveal` keys its `derivedStateOf` holders on `density`/`layoutDirection`, which were captured at first composition and went stale across configuration changes.
- `RevealState.reveal` KDoc documents that geometry now tracks the element, so callers no longer need to wait for a stable layout.

**Modifier node rewrite**

`Modifier.revealable` used `onGloballyPositioned` plus a `DisposableEffect` inside the deprecated `composed {}` factory. That effect was keyed on `Unit`, so changing the `keys` collection on a node that stayed in the composition never unregistered the old keys — they lingered in `RevealState` until the element was disposed.

Both halves are now one `ModifierNodeElement` / `Modifier.Node` implementing `GlobalPositionAwareModifierNode`, matching the existing `RevealOverlayAlignElement`. `update()` diffs the key set and removes what the node no longer owns. The node caches the last `Revealable.Layout` so a key or state change replays without waiting for another layout pass; only value types are retained, never the `LayoutCoordinates`.

Registration is deliberately *not* replayed for `shape`/`padding`/`borderStroke`/`onClick` changes — those are picked up by the next layout pass, as before. Replaying on every `update()` would write to `RevealState` on every recomposition, and the lambda-wrapping types above never compare equal, so that write could never settle.

## Public API

Additive only — `RoundRect` gains `equals`/`hashCode`/`toString`/`copy`. The modifier node rewrite changes no signatures. `api/` dumps regenerated via `./gradlew apiDump`.

## Tests

- `RevealOverlayGeometryTest.revealAreaFollowsTheElementWhenItMovesAfterBeingRevealed` (desktop) — overlay content tracks the target after it shifts.
- `RevealMovingRevealableTest` (Android instrumentation) — mirrors the repro from the issue thread: content inserted above the target while the effect is visible.

Also migrates `RevealInModalBottomSheetTest` to the v2 `createComposeRule`; it was the last test still using the deprecated v1 rule.

Not covered: the key-set leak fixed by the modifier node rewrite. No test in the suite changes `keys` on a live node.
