### PR TITLE
fix: clamp arranged overlay dimensions to avoid negative Constraints

### DIFF
--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayLayout.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayLayout.kt
@@ -45,8 +45,15 @@ internal fun RevealOverlayLayout(
                     // Loose constraints (min = 0): the incoming constraints are fixed to the full
                     // overlay size (RevealOverlayLayout itself uses matchParentSize()), but the
                     // child should only be bounded by, not forced to, the arranged layout area.
+                    // layoutSize.width is coerced to non-negative because revealableRect is
+                    // inflated by the revealable's padding and can extend past the overlay edge
+                    // (e.g. an edge-flush revealable), which would otherwise make arrange() return
+                    // a negative width and Constraints() throw.
                     placeables[index] = measurable.measure(
-                        Constraints(maxWidth = layoutSize.width, maxHeight = space.height),
+                        Constraints(
+                            maxWidth = layoutSize.width.coerceAtLeast(0),
+                            maxHeight = space.height,
+                        ),
                     )
                 }
 
@@ -58,7 +65,10 @@ internal fun RevealOverlayLayout(
                     )
                     layoutRects[index] = layoutSize
                     placeables[index] = measurable.measure(
-                        Constraints(maxWidth = space.width, maxHeight = layoutSize.height),
+                        Constraints(
+                            maxWidth = space.width,
+                            maxHeight = layoutSize.height.coerceAtLeast(0),
+                        ),
                     )
                 }
 

--- a/reveal-core/src/desktopTest/kotlin/com/svenjacobs/reveal/RevealOverlayEdgeFlushTest.kt
+++ b/reveal-core/src/desktopTest/kotlin/com/svenjacobs/reveal/RevealOverlayEdgeFlushTest.kt
@@ -1,0 +1,164 @@
+package com.svenjacobs.reveal
+
+import androidx.compose.animation.core.snap
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.svenjacobs.reveal.effect.dim.DimRevealOverlayEffect
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Regression tests for issue #376: [Revealable.computeArea] inflates the reveal area by the
+ * revealable's padding (8dp by default) without clamping to the overlay bounds, so an element
+ * flush with a window edge produces a reveal area that extends past that edge. When
+ * [RevealOverlayArrangement] then arranges overlay content on the outside of that edge (e.g.
+ * [RevealOverlayArrangement.Top] for a top-flush element), the arranged area has a negative
+ * width or height, which used to be passed straight into `Constraints(...)` and crash with
+ * `IllegalArgumentException`.
+ *
+ * These live in the desktop source set for the same reason as [RevealOverlayGeometryTest]: it is
+ * the only target where the skiko popup implementation can be exercised without a device.
+ */
+@OptIn(ExperimentalTestApi::class)
+class RevealOverlayEdgeFlushTest {
+
+    @Test
+    fun alignTopDoesNotCrashForATopFlushRevealable() = runComposeUiTest {
+        revealEdgeFlushAndWaitForOverlay(targetAlignment = Alignment.TopCenter) {
+            Box(
+                modifier = Modifier
+                    .align(verticalArrangement = RevealOverlayArrangement.Top)
+                    .size(80.dp)
+                    .testTag(OVERLAY_TAG),
+            )
+        }
+
+        val overlay = onNodeWithTag(OVERLAY_TAG).fetchSemanticsNode().boundsInWindow
+        assertTrue(
+            overlay.top >= 0f,
+            "Overlay content should stay within the window, but was $overlay",
+        )
+    }
+
+    @Test
+    fun alignBottomDoesNotCrashForABottomFlushRevealable() = runComposeUiTest {
+        revealEdgeFlushAndWaitForOverlay(targetAlignment = Alignment.BottomCenter) {
+            Box(
+                modifier = Modifier
+                    .align(verticalArrangement = RevealOverlayArrangement.Bottom)
+                    .size(80.dp)
+                    .testTag(OVERLAY_TAG),
+            )
+        }
+
+        val window = onNodeWithTag(WINDOW_TAG).fetchSemanticsNode().boundsInWindow
+        val overlay = onNodeWithTag(OVERLAY_TAG).fetchSemanticsNode().boundsInWindow
+        assertTrue(
+            overlay.bottom <= window.bottom,
+            "Overlay content should stay within the window, but overlay=$overlay window=$window",
+        )
+    }
+
+    @Test
+    fun alignStartDoesNotCrashForAStartFlushRevealable() = runComposeUiTest {
+        revealEdgeFlushAndWaitForOverlay(targetAlignment = Alignment.CenterStart) {
+            Box(
+                modifier = Modifier
+                    .align(horizontalArrangement = RevealOverlayArrangement.Start)
+                    .size(80.dp)
+                    .testTag(OVERLAY_TAG),
+            )
+        }
+
+        val overlay = onNodeWithTag(OVERLAY_TAG).fetchSemanticsNode().boundsInWindow
+        assertTrue(
+            overlay.left >= 0f,
+            "Overlay content should stay within the window, but was $overlay",
+        )
+    }
+
+    @Test
+    fun alignEndDoesNotCrashForAnEndFlushRevealable() = runComposeUiTest {
+        revealEdgeFlushAndWaitForOverlay(targetAlignment = Alignment.CenterEnd) {
+            Box(
+                modifier = Modifier
+                    .align(horizontalArrangement = RevealOverlayArrangement.End)
+                    .size(80.dp)
+                    .testTag(OVERLAY_TAG),
+            )
+        }
+
+        val window = onNodeWithTag(WINDOW_TAG).fetchSemanticsNode().boundsInWindow
+        val overlay = onNodeWithTag(OVERLAY_TAG).fetchSemanticsNode().boundsInWindow
+        assertTrue(
+            overlay.right <= window.right,
+            "Overlay content should stay within the window, but overlay=$overlay window=$window",
+        )
+    }
+
+    /**
+     * Reveals a target flush with the edge of the window implied by [targetAlignment], using the
+     * default 8dp revealable padding so that [Revealable.computeArea] pushes the reveal area past
+     * that edge, and waits for the overlay content built by [overlayContent] to appear.
+     */
+    private fun ComposeUiTest.revealEdgeFlushAndWaitForOverlay(
+        targetAlignment: Alignment,
+        overlayContent: @Composable RevealOverlayScope.(key: Key) -> Unit,
+    ) {
+        lateinit var revealState: RevealState
+        lateinit var scope: CoroutineScope
+
+        setContent {
+            revealState = rememberRevealState()
+            scope = rememberCoroutineScope()
+
+            Reveal(
+                modifier = Modifier.fillMaxSize().testTag(WINDOW_TAG),
+                revealState = revealState,
+                // Instant animations so the overlay is fully laid out once it appears.
+                overlayEffect = DimRevealOverlayEffect(
+                    alphaAnimationSpec = snap(),
+                    contentAlphaAnimationSpec = snap(),
+                ),
+                overlayContent = overlayContent,
+            ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Box(
+                        modifier = Modifier
+                            .align(targetAlignment)
+                            .size(48.dp)
+                            .testTag(TARGET_TAG)
+                            .revealable(key = KEY),
+                    )
+                }
+            }
+        }
+
+        waitForIdle()
+        scope.launch { revealState.reveal(KEY) }
+        waitUntil(timeoutMillis = 5_000) {
+            onAllNodesWithTag(OVERLAY_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private companion object {
+        const val WINDOW_TAG = "window"
+        const val TARGET_TAG = "target"
+        const val OVERLAY_TAG = "overlayContent"
+        val KEY: Key = "key"
+    }
+}


### PR DESCRIPTION
## Summary
- `RevealOverlayLayout` built `Constraints` directly from `RevealOverlayArrangement.arrange()` output, which can be negative when a revealable's padding-inflated reveal area extends past the overlay edge (e.g. an element flush with the window edge), crashing with `IllegalArgumentException`.
- Clamp the arranged width/height to `>= 0` before constructing `Constraints`, matching the existing defensive clamp already used at placement time (`coerceWithin`).
- Add `RevealOverlayEdgeFlushTest` (desktop source set) covering all four `RevealOverlayArrangement` values against an edge-flush revealable.

Closes #376

## Test plan
- [x] `./gradlew :reveal-core:desktopTest --tests "com.svenjacobs.reveal.RevealOverlayEdgeFlushTest"`
- [x] `./gradlew check`
- [x] `./gradlew :android-tests:verifyRoborazziDebug`
- [x] `./gradlew connectedAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)