### PR TITLE
fix: clamp arranged overlay areas in RevealOverlayArrangement.arrange()

### DIFF
--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayArrangement.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayArrangement.kt
@@ -13,11 +13,12 @@ public object RevealOverlayArrangement {
             space: IntSize,
             confineHeight: Boolean,
             layoutDirection: LayoutDirection,
-        ): IntRect = IntRect(
+        ): IntRect = arrangedRect(
             left = if (layoutDirection == LayoutDirection.Ltr) 0 else revealable.right,
             top = if (confineHeight) revealable.top else 0,
             right = if (layoutDirection == LayoutDirection.Ltr) revealable.left else space.width,
             bottom = if (confineHeight) revealable.bottom else space.height,
+            space = space,
         )
 
         override fun align(size: Int, layout: Int, space: Int): Int = layout - size
@@ -30,11 +31,12 @@ public object RevealOverlayArrangement {
             space: IntSize,
             confineHeight: Boolean,
             layoutDirection: LayoutDirection,
-        ): IntRect = IntRect(
+        ): IntRect = arrangedRect(
             left = if (layoutDirection == LayoutDirection.Ltr) revealable.right else 0,
             top = if (confineHeight) revealable.top else 0,
             right = if (layoutDirection == LayoutDirection.Ltr) space.width else revealable.left,
             bottom = if (confineHeight) revealable.bottom else space.height,
+            space = space,
         )
 
         override fun align(size: Int, layout: Int, space: Int): Int = space - layout
@@ -43,11 +45,12 @@ public object RevealOverlayArrangement {
     public data object Top : Vertical {
 
         override fun arrange(revealable: IntRect, space: IntSize, confineWidth: Boolean): IntRect =
-            IntRect(
+            arrangedRect(
                 left = if (confineWidth) revealable.left else 0,
                 top = 0,
                 right = if (confineWidth) revealable.right else space.width,
                 bottom = revealable.top,
+                space = space,
             )
 
         override fun align(size: Int, layout: Int, space: Int): Int = layout - size
@@ -56,11 +59,12 @@ public object RevealOverlayArrangement {
     public data object Bottom : Vertical {
 
         override fun arrange(revealable: IntRect, space: IntSize, confineWidth: Boolean): IntRect =
-            IntRect(
+            arrangedRect(
                 left = if (confineWidth) revealable.left else 0,
                 top = revealable.bottom,
                 right = if (confineWidth) revealable.right else space.width,
                 bottom = space.height,
+                space = space,
             )
 
         override fun align(size: Int, layout: Int, space: Int): Int = space - layout
@@ -71,6 +75,13 @@ public object RevealOverlayArrangement {
         /**
          * Returns an [IntRect] which represents the position and size of the overlay layout area
          * for a [revealable] within available [space].
+         *
+         * The returned rect is always contained within [space] and never has a negative width or
+         * height, so that its dimensions can be passed to `Constraints` unchecked. When there is
+         * no room on the arranged side, the area collapses to zero rather than inverting.
+         *
+         * [space] itself is expected to be non-negative, which holds for the maximum dimensions of
+         * any `Constraints`.
          */
         public fun arrange(
             revealable: IntRect,
@@ -91,6 +102,13 @@ public object RevealOverlayArrangement {
         /**
          * Returns an [IntRect] which represents the position and size of the overlay layout area
          * for a [revealable] within available [space].
+         *
+         * The returned rect is always contained within [space] and never has a negative width or
+         * height, so that its dimensions can be passed to `Constraints` unchecked. When there is
+         * no room on the arranged side, the area collapses to zero rather than inverting.
+         *
+         * [space] itself is expected to be non-negative, which holds for the maximum dimensions of
+         * any `Constraints`.
          */
         public fun arrange(revealable: IntRect, space: IntSize, confineWidth: Boolean): IntRect
 
@@ -100,4 +118,22 @@ public object RevealOverlayArrangement {
          */
         public fun align(size: Int, layout: Int, space: Int): Int
     }
+}
+
+/**
+ * Builds an arranged layout area that is always contained within [space] and never has a negative
+ * width or height, so that it can be passed to `Constraints` unchecked. Edges are clamped rather
+ * than the rect being rejected: a reveal area inflated past a window edge (by the revealable's
+ * padding, or by the circle-shape expansion in [computeArea]) collapses the area on that side to
+ * zero instead of inverting it.
+ */
+private fun arrangedRect(left: Int, top: Int, right: Int, bottom: Int, space: IntSize): IntRect {
+    val clampedLeft = left.coerceIn(0, space.width)
+    val clampedTop = top.coerceIn(0, space.height)
+    return IntRect(
+        left = clampedLeft,
+        top = clampedTop,
+        right = right.coerceIn(clampedLeft, space.width),
+        bottom = bottom.coerceIn(clampedTop, space.height),
+    )
 }

--- a/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayLayout.kt
+++ b/reveal-core/src/commonMain/kotlin/com/svenjacobs/reveal/RevealOverlayLayout.kt
@@ -45,15 +45,10 @@ internal fun RevealOverlayLayout(
                     // Loose constraints (min = 0): the incoming constraints are fixed to the full
                     // overlay size (RevealOverlayLayout itself uses matchParentSize()), but the
                     // child should only be bounded by, not forced to, the arranged layout area.
-                    // layoutSize.width is coerced to non-negative because revealableRect is
-                    // inflated by the revealable's padding and can extend past the overlay edge
-                    // (e.g. an edge-flush revealable), which would otherwise make arrange() return
-                    // a negative width and Constraints() throw.
+                    // arrange() guarantees that layoutSize lies within space and has no negative
+                    // dimension, so it is safe to pass straight into Constraints().
                     placeables[index] = measurable.measure(
-                        Constraints(
-                            maxWidth = layoutSize.width.coerceAtLeast(0),
-                            maxHeight = space.height,
-                        ),
+                        Constraints(maxWidth = layoutSize.width, maxHeight = space.height),
                     )
                 }
 
@@ -65,10 +60,7 @@ internal fun RevealOverlayLayout(
                     )
                     layoutRects[index] = layoutSize
                     placeables[index] = measurable.measure(
-                        Constraints(
-                            maxWidth = space.width,
-                            maxHeight = layoutSize.height.coerceAtLeast(0),
-                        ),
+                        Constraints(maxWidth = space.width, maxHeight = layoutSize.height),
                     )
                 }
 

--- a/reveal-core/src/commonTest/kotlin/com/svenjacobs/reveal/RevealOverlayArrangementTest.kt
+++ b/reveal-core/src/commonTest/kotlin/com/svenjacobs/reveal/RevealOverlayArrangementTest.kt
@@ -1,0 +1,196 @@
+package com.svenjacobs.reveal
+
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the geometry contract of [RevealOverlayArrangement.arrange]: the returned layout area
+ * must always lie within the available space and never have a negative width or height, so that its
+ * dimensions can be passed to `Constraints` unchecked.
+ *
+ * Regression tests for issue #376: [computeArea] inflates the reveal area by the revealable's
+ * padding (8dp by default) and, for [RevealShape.Circle], by the circle expansion around its
+ * centre, without clamping to the overlay bounds. A revealable flush with a window edge therefore
+ * produces a reveal area that extends past that edge, and arranging overlay content on the outside
+ * of that edge used to return an inverted rect whose negative dimension crashed `Constraints`.
+ */
+class RevealOverlayArrangementTest {
+
+    @Test
+    fun arrangeReturnsUnchangedGeometryForAnInBoundsRevealable() {
+        val revealable = IntRect(left = 400, top = 800, right = 600, bottom = 1000)
+
+        // Clamping must be a no-op while the reveal area is fully inside the space.
+        assertEquals(
+            IntRect(left = 0, top = 800, right = 400, bottom = 1000),
+            RevealOverlayArrangement.Start.arrange(revealable, SPACE, true, LayoutDirection.Ltr),
+        )
+        assertEquals(
+            IntRect(left = 0, top = 0, right = 400, bottom = 2000),
+            RevealOverlayArrangement.Start.arrange(revealable, SPACE, false, LayoutDirection.Ltr),
+        )
+        assertEquals(
+            IntRect(left = 600, top = 800, right = 1000, bottom = 1000),
+            RevealOverlayArrangement.Start.arrange(revealable, SPACE, true, LayoutDirection.Rtl),
+        )
+        assertEquals(
+            IntRect(left = 600, top = 800, right = 1000, bottom = 1000),
+            RevealOverlayArrangement.End.arrange(revealable, SPACE, true, LayoutDirection.Ltr),
+        )
+        assertEquals(
+            IntRect(left = 0, top = 800, right = 400, bottom = 1000),
+            RevealOverlayArrangement.End.arrange(revealable, SPACE, true, LayoutDirection.Rtl),
+        )
+        assertEquals(
+            IntRect(left = 400, top = 0, right = 600, bottom = 800),
+            RevealOverlayArrangement.Top.arrange(revealable, SPACE, true),
+        )
+        assertEquals(
+            IntRect(left = 0, top = 0, right = 1000, bottom = 800),
+            RevealOverlayArrangement.Top.arrange(revealable, SPACE, false),
+        )
+        assertEquals(
+            IntRect(left = 400, top = 1000, right = 600, bottom = 2000),
+            RevealOverlayArrangement.Bottom.arrange(revealable, SPACE, true),
+        )
+        assertEquals(
+            IntRect(left = 0, top = 1000, right = 1000, bottom = 2000),
+            RevealOverlayArrangement.Bottom.arrange(revealable, SPACE, false),
+        )
+    }
+
+    @Test
+    fun arrangeCollapsesTheLayoutAreaWhenTheRevealableCrossesTheArrangedEdge() {
+        // Top edge: nothing above a revealable whose inflated area starts above the space.
+        val topFlush = IntRect(left = 400, top = -20, right = 600, bottom = 180)
+        assertEquals(
+            IntRect(left = 400, top = 0, right = 600, bottom = 0),
+            RevealOverlayArrangement.Top.arrange(topFlush, SPACE, true),
+        )
+
+        // Bottom edge.
+        val bottomFlush = IntRect(left = 400, top = 1900, right = 600, bottom = 2020)
+        assertEquals(
+            IntRect(left = 400, top = 2000, right = 600, bottom = 2000),
+            RevealOverlayArrangement.Bottom.arrange(bottomFlush, SPACE, true),
+        )
+
+        // Start edge (Ltr), and the same area arranged Rtl, where End is the one that collapses.
+        val startFlush = IntRect(left = -20, top = 800, right = 180, bottom = 1000)
+        assertEquals(
+            IntRect(left = 0, top = 800, right = 0, bottom = 1000),
+            RevealOverlayArrangement.Start.arrange(startFlush, SPACE, true, LayoutDirection.Ltr),
+        )
+        assertEquals(
+            IntRect(left = 0, top = 800, right = 0, bottom = 1000),
+            RevealOverlayArrangement.End.arrange(startFlush, SPACE, true, LayoutDirection.Rtl),
+        )
+
+        // End edge (Ltr).
+        val endFlush = IntRect(left = 900, top = 800, right = 1020, bottom = 1000)
+        assertEquals(
+            IntRect(left = 1000, top = 800, right = 1000, bottom = 1000),
+            RevealOverlayArrangement.End.arrange(endFlush, SPACE, true, LayoutDirection.Ltr),
+        )
+        assertEquals(
+            IntRect(left = 1000, top = 800, right = 1000, bottom = 1000),
+            RevealOverlayArrangement.Start.arrange(endFlush, SPACE, true, LayoutDirection.Rtl),
+        )
+    }
+
+    @Test
+    fun arrangeClampsTheConfinedCrossAxisToTheSpace() {
+        // A revealable crossing the top edge still has room beside it, but the confined cross axis
+        // is clamped to the visible part of the reveal area rather than starting off-screen.
+        val topFlush = IntRect(left = 400, top = -20, right = 600, bottom = 180)
+        assertEquals(
+            IntRect(left = 600, top = 0, right = 1000, bottom = 180),
+            RevealOverlayArrangement.End.arrange(topFlush, SPACE, true, LayoutDirection.Ltr),
+        )
+
+        val bottomFlush = IntRect(left = 400, top = 1900, right = 600, bottom = 2020)
+        assertEquals(
+            IntRect(left = 0, top = 1900, right = 400, bottom = 2000),
+            RevealOverlayArrangement.Start.arrange(bottomFlush, SPACE, true, LayoutDirection.Ltr),
+        )
+
+        val startFlush = IntRect(left = -20, top = 800, right = 180, bottom = 1000)
+        assertEquals(
+            IntRect(left = 0, top = 0, right = 180, bottom = 800),
+            RevealOverlayArrangement.Top.arrange(startFlush, SPACE, true),
+        )
+    }
+
+    @Test
+    fun arrangeStaysWithinTheSpaceForEveryArrangementAndRevealable() {
+        val revealables = listOf(
+            // Fully inside.
+            IntRect(left = 400, top = 800, right = 600, bottom = 1000),
+            // Crossing each edge.
+            IntRect(left = 400, top = -20, right = 600, bottom = 180),
+            IntRect(left = 400, top = 1900, right = 600, bottom = 2020),
+            IntRect(left = -20, top = 800, right = 180, bottom = 1000),
+            IntRect(left = 900, top = 800, right = 1020, bottom = 1000),
+            // Entirely outside, as for a revealable scrolled out of the window.
+            IntRect(left = -500, top = -500, right = -100, bottom = -100),
+            IntRect(left = 1100, top = 2100, right = 1500, bottom = 2500),
+            // Larger than the space in both axes.
+            IntRect(left = -100, top = -100, right = 1100, bottom = 2100),
+        )
+
+        for (revealable in revealables) {
+            for ((name, rect) in allArrangements(revealable, SPACE)) {
+                assertValid(rect = rect, space = SPACE, description = "$name for $revealable")
+            }
+        }
+    }
+
+    private fun allArrangements(revealable: IntRect, space: IntSize): List<Pair<String, IntRect>> =
+        buildList {
+            for (confine in listOf(true, false)) {
+                for (direction in listOf(LayoutDirection.Ltr, LayoutDirection.Rtl)) {
+                    add(
+                        "Start(confine=$confine, $direction)" to
+                            RevealOverlayArrangement.Start
+                                .arrange(revealable, space, confine, direction),
+                    )
+                    add(
+                        "End(confine=$confine, $direction)" to
+                            RevealOverlayArrangement.End
+                                .arrange(revealable, space, confine, direction),
+                    )
+                }
+                add(
+                    "Top(confine=$confine)" to
+                        RevealOverlayArrangement.Top.arrange(revealable, space, confine),
+                )
+                add(
+                    "Bottom(confine=$confine)" to
+                        RevealOverlayArrangement.Bottom.arrange(revealable, space, confine),
+                )
+            }
+        }
+
+    private fun assertValid(rect: IntRect, space: IntSize, description: String) {
+        assertTrue(rect.width >= 0, "$description: width must not be negative, but was $rect")
+        assertTrue(rect.height >= 0, "$description: height must not be negative, but was $rect")
+        assertTrue(rect.left >= 0, "$description: left must be within the space, but was $rect")
+        assertTrue(rect.top >= 0, "$description: top must be within the space, but was $rect")
+        assertTrue(
+            rect.right <= space.width,
+            "$description: right must be within the space, but was $rect",
+        )
+        assertTrue(
+            rect.bottom <= space.height,
+            "$description: bottom must be within the space, but was $rect",
+        )
+    }
+
+    private companion object {
+        val SPACE = IntSize(width = 1000, height = 2000)
+    }
+}

--- a/reveal-core/src/desktopTest/kotlin/com/svenjacobs/reveal/RevealOverlayEdgeFlushTest.kt
+++ b/reveal-core/src/desktopTest/kotlin/com/svenjacobs/reveal/RevealOverlayEdgeFlushTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.svenjacobs.reveal.effect.dim.DimRevealOverlayEffect
 import kotlin.test.Test
@@ -23,12 +24,16 @@ import kotlinx.coroutines.launch
 
 /**
  * Regression tests for issue #376: [Revealable.computeArea] inflates the reveal area by the
- * revealable's padding (8dp by default) without clamping to the overlay bounds, so an element
- * flush with a window edge produces a reveal area that extends past that edge. When
- * [RevealOverlayArrangement] then arranges overlay content on the outside of that edge (e.g.
- * [RevealOverlayArrangement.Top] for a top-flush element), the arranged area has a negative
- * width or height, which used to be passed straight into `Constraints(...)` and crash with
- * `IllegalArgumentException`.
+ * revealable's padding (8dp by default) — and, for [RevealShape.Circle], by the circle expansion
+ * around its centre — without clamping to the overlay bounds, so an element flush with a window
+ * edge produces a reveal area that extends past that edge. When [RevealOverlayArrangement] then
+ * arranges overlay content on the outside of that edge (e.g. [RevealOverlayArrangement.Top] for a
+ * top-flush element), the arranged area used to have a negative width or height, which was passed
+ * straight into `Constraints(...)` and crashed with `IllegalArgumentException`.
+ *
+ * [RevealOverlayArrangementTest] covers the same clamping at the level of the arranged geometry
+ * alone; these tests exercise it through a real composition, including the inflation that produces
+ * the out-of-bounds reveal area in the first place.
  *
  * These live in the desktop source set for the same reason as [RevealOverlayGeometryTest]: it is
  * the only target where the skiko popup implementation can be exercised without a device.
@@ -110,13 +115,46 @@ class RevealOverlayEdgeFlushTest {
         )
     }
 
+    @Test
+    fun alignTopDoesNotCrashForAWideCircleShapedRevealable() = runComposeUiTest {
+        // The other inflation source: RevealShape.Circle expands the area to a square of
+        // maxDimension / 2 around its centre, so a wide, short element grows by far more than the
+        // padding along the short axis. Here that pushes the reveal area roughly 116dp above the
+        // top edge, well past what the 8dp padding alone would do.
+        revealEdgeFlushAndWaitForOverlay(
+            targetAlignment = Alignment.TopCenter,
+            shape = RevealShape.Circle,
+            targetWidth = 240.dp,
+            targetHeight = 24.dp,
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(verticalArrangement = RevealOverlayArrangement.Top)
+                    .size(80.dp)
+                    .testTag(OVERLAY_TAG),
+            )
+        }
+
+        val overlay = onNodeWithTag(OVERLAY_TAG).fetchSemanticsNode().boundsInWindow
+        assertTrue(
+            overlay.top >= 0f,
+            "Overlay content should stay within the window, but was $overlay",
+        )
+    }
+
     /**
-     * Reveals a target flush with the edge of the window implied by [targetAlignment], using the
-     * default 8dp revealable padding so that [Revealable.computeArea] pushes the reveal area past
-     * that edge, and waits for the overlay content built by [overlayContent] to appear.
+     * Reveals a target of [targetWidth] x [targetHeight] flush with the edge of the window implied
+     * by [targetAlignment], using the default 8dp revealable padding so that
+     * [Revealable.computeArea] pushes the reveal area past that edge, and waits for the overlay
+     * content built by [overlayContent] to appear. [shape] defaults to the same shape as
+     * [RevealScope.revealable]; pass [RevealShape.Circle] to additionally exercise the circle
+     * expansion in [Revealable.computeArea].
      */
     private fun ComposeUiTest.revealEdgeFlushAndWaitForOverlay(
         targetAlignment: Alignment,
+        shape: RevealShape = RevealShape.RoundRect(4.dp),
+        targetWidth: Dp = 48.dp,
+        targetHeight: Dp = 48.dp,
         overlayContent: @Composable RevealOverlayScope.(key: Key) -> Unit,
     ) {
         lateinit var revealState: RevealState
@@ -140,9 +178,9 @@ class RevealOverlayEdgeFlushTest {
                     Box(
                         modifier = Modifier
                             .align(targetAlignment)
-                            .size(48.dp)
+                            .size(width = targetWidth, height = targetHeight)
                             .testTag(TARGET_TAG)
-                            .revealable(key = KEY),
+                            .revealable(key = KEY, shape = shape),
                     )
                 }
             }


### PR DESCRIPTION
Follow-up hardening to #377, which fixed the `Constraints` crash from #376.

## What was still wrong

#377 stopped the crash by coercing the arranged dimensions to non-negative at the two `measure()` call sites in `RevealOverlayLayout`. That left `arrange()` itself — **public API** — free to return inverted rects and coordinates outside the available space:

```kotlin
// Top, for a revealable whose inflated area starts above the overlay
IntRect(left = …, top = 0, right = …, bottom = revealable.top /* negative */)
```

The placement block then fed those values into `arrangement.align(layout = …)` and `verticalAlignment.align(space = …)` as a negative layout extent, producing offsets that only `coerceWithin` rescued. Third-party callers of `arrange()` got no guarantee at all.

## What this does

Route all four `arrange()` implementations through a private `arrangedRect()` helper that coerces every edge into `space` and keeps `right >= left` / `bottom >= top`. The returned rect can no longer invert or fall outside the space, so an area with no room on the arranged side collapses to zero instead. The two measure sites drop their `coerceAtLeast(0)` band-aids and pass the dimensions to `Constraints()` unchanged, and the placement math becomes correct by construction.

`coerceWithin` stays — it still handles a *child* larger than the arranged area, which clamping `arrange()` does not address.

The guarantee is now documented on `arrange()` in both `Horizontal` and `Vertical`. Signatures are unchanged, so no `apiDump` is needed.

## Behaviour change

The confined cross axis is clamped as well. Overlay content aligned to a revealable that crosses a window edge now centres on the **visible** part of the reveal area rather than on its partly off-window centre — a few px, and only for revealables that actually cross an edge. Revealables fully inside the window are bit-identical, since every coercion is a no-op there.

`RevealOverlayScreenshotTest`'s 72-case matrix insets each target by `.padding(24.dp)` plus the 8dp revealable padding, so no case crosses an edge and **no baseline should shift**. A diff from `verifyRoborazziDebug` would mean something changed that should not have — inspect before re-recording.

## Tests

- **`RevealOverlayArrangementTest`** (new, first file in `reveal-core`'s `commonTest` source set) — exact-geometry assertions proving clamping is a no-op for an in-bounds revealable; collapse-to-zero assertions for each crossed edge in both `Ltr` and `Rtl`; cross-axis clamp assertions; and an invariant sweep over all four arrangements x both `confine` values x both layout directions for eight revealables, including ones entirely outside the space and one larger than it.
- **`RevealOverlayEdgeFlushTest`** — added a case for the other inflation source: `RevealShape.Circle` on a 240x24dp element at `TopCenter` expands the reveal area ~116dp above the window edge, far past what the 8dp padding alone does. The shared helper gained `shape` / `targetWidth` / `targetHeight` parameters defaulting to today's values.

## Verification

Not run locally — the dev container is linux/aarch64, which Kotlin/Native does not support as a *host*, so `./gradlew` fails to configure at plugin-apply (`Unknown host target: linux aarch64`). Relying on CI for `check`, `verifyRoborazziDebug`, and `connectedAndroidTest` on API 23/29.

## Context

The crash was originally reported against a production app on <= v4.3.0, whose stack trace still showed the pre-#353 `Modifier.layout` implementation (`RevealOverlayScopeInstance.align$lambda$0` -> `Constraints.copy`). That app should upgrade to v5.1.1 regardless; this PR is hardening on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
